### PR TITLE
Use iframe-resizer

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   },
   "homepage": "https://github.com/Brightspace/ifrau",
   "dependencies": {
-    "babel-runtime": "^5.5.8"
+    "babel-runtime": "^5.5.8",
+    "iframe-resizer": "git://github.com/rschick/iframe-resizer.git#optional_window"
   },
   "devDependencies": {
     "babel": "^5.6.4",

--- a/src/client.js
+++ b/src/client.js
@@ -8,20 +8,12 @@ export default class Client extends Port {
 		this.lastHeight = 0;
 
 	}
-	adjustHeight() {
-		var height = document.body.scrollHeight;
-		if(height != this.lastHeight) {
-			this.lastHeight = height;
-			this.sendEventRaw('height', [height]);
-		}
-	}
 	connect() {
 		var me = this;
 		return new Promise((resolve, reject) => {
 
 			me.open();
 			me.sendEventRaw('ready');
-			setInterval(me.adjustHeight.bind(me), 100);
 
 			super.connect();
 			resolve();

--- a/src/host.js
+++ b/src/host.js
@@ -1,4 +1,5 @@
 import Port from './port';
+import {default as resizer} from 'iframe-resizer';
 
 var originRe = /^(http:\/\/|https:\/\/)[^\/]+/i;
 
@@ -22,6 +23,7 @@ export default class Host extends Port {
 
 		this.iframe = iframe;
 
+		resizer.iframeResizer({}, iframe);
 	}
 	connect() {
 		var me = this;
@@ -29,8 +31,6 @@ export default class Host extends Port {
 			me.onEvent('ready', function() {
 				super.connect();
 				resolve();
-			}).onEvent('height', function(height) {
-				me.iframe.style.height = height + 'px';
 			}).onEvent('title', function(title) {
 				document.title = title;
 			}).onEvent('navigate', function(url) {

--- a/test/client.js
+++ b/test/client.js
@@ -35,33 +35,15 @@ describe('client', () => {
 		clock.restore();
 	});
 
-	describe('adjustHeight', () => {
-
-		it('should not send event if height has not changed', () => {
-			global.document.body.scrollHeight = 0;
-			client.adjustHeight();
-			sendEventRaw.should.not.have.been.called;
-		});
-
-		it('should send event if height has changed', () => {
-			global.document.body.scrollHeight = 200;
-			client.adjustHeight();
-			sendEventRaw.should.have.been.calledWith('height', [200]);
-		});
-
-	});
-
 	describe('connect', () => {
 
-		var adjustHeight, open;
+		var open;
 
 		beforeEach(() => {
-			adjustHeight = sinon.stub(client, 'adjustHeight');
 			open = sinon.stub(client, 'open');
 		});
 
 		afterEach(() => {
-			adjustHeight.restore();
 			open.restore();
 		});
 
@@ -79,15 +61,6 @@ describe('client', () => {
 		it('should send the "ready" event', () => {
 			client.connect();
 			sendEventRaw.should.have.been.calledWith('ready');
-		});
-
-		it('should adjustHeight every 100ms', () => {
-			client.connect();
-			adjustHeight.should.not.have.been.called;
-			clock.tick(100);
-			adjustHeight.should.have.been.calledOnce;
-			clock.tick(100);
-			adjustHeight.should.have.been.calledTwice;
 		});
 
 	});

--- a/test/host.js
+++ b/test/host.js
@@ -1,6 +1,7 @@
 var chai = require('chai'),
 	expect = chai.expect,
-	sinon = require('sinon');
+	sinon = require('sinon'),
+	resizer = require('iframe-resizer');
 
 chai.should();
 chai.use(require('sinon-chai'));
@@ -44,8 +45,12 @@ describe('host', () => {
 				location: { origin: 'origin' }
 			};
 			global.document = {
-				createElement: sinon.stub().returns({style:{}}),
-				getElementById: sinon.stub().returns()
+				createElement: sinon.stub().returns({style: {}, tagName: 'iframe'}),
+				getElementById: sinon.stub().returns(),
+				title: 'title',
+				location: {
+					href: 'url'
+				}
 			};
 			callback = sinon.spy();
 			element = { appendChild: sinon.spy() };
@@ -75,11 +80,23 @@ describe('host', () => {
 			host.receiveEvent('ready');
 		});
 
-		['ready', 'height', 'title', 'navigate'].forEach((evt) => {
+		['ready', 'title', 'navigate'].forEach((evt) => {
 			it(`should register for the "${evt}" event`, () => {
 				host.connect();
 				onEvent.should.have.been.calledWith(evt);
 			});
+		});
+
+		it('should update the document title', () => {
+			host.connect();
+			host.receiveEvent('title', ['new title']);
+			global.document.title.should.equal('new title');
+		});
+
+		it('should update the document location', () => {
+			host.connect();
+			host.receiveEvent('navigate', ['new url']);
+			global.document.location.href.should.equal('new url');
 		});
 
 	});

--- a/test/index.js
+++ b/test/index.js
@@ -14,7 +14,7 @@ describe('ifrau', () => {
 			addEventListener: sinon.stub()
 		};
 		global.document = {
-			createElement: sinon.stub().returns({style:{}}),
+			createElement: sinon.stub().returns({style: {}, tagName: 'iframe'}),
 			getElementById: sinon.stub().returns({
 				appendChild: sinon.spy()
 			})


### PR DESCRIPTION
I've tested this with Chrome, Firefox and Safari on Mac, and iframe-resizer works better than the simple scrollHeight change we were using before: the iframe will shrink as well as grow, whereas before it wouldn't shrink.

I had to modify the iframe-resizer library to get it to load for tests. I submitted a PR and will update here when that gets accepted.
