### PR TITLE
[WIP] add syntax for host plugins

### DIFF
--- a/src/host.js
+++ b/src/host.js
@@ -43,6 +43,10 @@ export default class Host extends Port {
 		this.resizer.close(this.iframe);
 		super.close();
 	}
+	using(plugin) {
+		plugin(this);
+		return this;
+	}
 	static createIFrame(src) {
 		var iframe = document.createElement('iframe');
 		iframe.width = '100%';


### PR DESCRIPTION
@dlockhart 

Random thought

```js
import { Host } from 'ifrau';
import { host as jwtHost } from 'frau-jwt';

const host = new Host()
  .using(jwtHost)
  .connect()
  // ...
  ;
```

```js
export host function jwtHost (host) {
  host.onRequest('foo', 'bar');
}
```