### PR TITLE
Allow many clients

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
   "homepage": "https://github.com/Brightspace/ifrau",
   "dependencies": {
     "babel-runtime": "^5.5.8",
-    "iframe-resizer": "git://github.com/rschick/iframe-resizer.git#cleanup"
+    "iframe-resizer": "git://github.com/rschick/iframe-resizer.git#cleanup",
+    "uuid": "^2.0.1"
   },
   "devDependencies": {
     "babel": "^5.6.4",

--- a/src/port.js
+++ b/src/port.js
@@ -1,3 +1,5 @@
+import uuid from 'uuid';
+
 let typeNameValidator = /^[a-zA-Z]+[a-zA-Z\-]*$/;
 
 export default class Port {
@@ -10,10 +12,12 @@ export default class Port {
 		this.isOpen = false;
 		this.pendingRequests = {};
 		this.requestHandlers = {};
-		this.requestId = 0;
 		this.services = {};
 		this.targetOrigin = targetOrigin;
 		this.waitingRequests = [];
+
+		this.id = uuid();
+		this.requestCounter = 0;
 	}
 	close() {
 		if(!this.isOpen) {
@@ -173,7 +177,7 @@ export default class Port {
 		}
 		var me = this;
 		return new Promise((resolve, reject) => {
-			var id = ++me.requestId;
+			const id = `${me.id}_${++me.requestCounter}`;
 			me.initHashArrAndPush(
 					me.pendingRequests,
 					requestType,

--- a/test/port.js
+++ b/test/port.js
@@ -525,7 +525,7 @@ describe('port', () => {
 			port.connect().request('foo');
 			sendMessage.should.have.been.calledWith(
 				'req.foo',
-				{ id: 1, args: [] }
+				{ id: `${port.id}_1`, args: [] }
 			);
 		});
 
@@ -533,7 +533,7 @@ describe('port', () => {
 			port.connect().request('foo', 'bar', true, -3);
 			sendMessage.should.have.been.calledWith(
 				'req.foo',
-				{ id: 1, args: ['bar', true, -3] }
+				{ id: `${port.id}_1`, args: ['bar', true, -3] }
 			);
 		});
 
@@ -541,8 +541,8 @@ describe('port', () => {
 			port.connect();
 			port.request('foo');
 			port.request('bar');
-			sendMessage.should.have.been.calledWith('req.foo', { id: 1, args: [] } );
-			sendMessage.should.have.been.calledWith('req.bar', { id: 2, args: [] } );
+			sendMessage.should.have.been.calledWith('req.foo', { id: `${port.id}_1`, args: [] } );
+			sendMessage.should.have.been.calledWith('req.bar', { id: `${port.id}_2`, args: [] } );
 		});
 
 	});


### PR DESCRIPTION
~~The only actual change to allow many clients is probably the request id stuff (1212bd437cdf599626ab083a8fa824320f03c536).~~

~~I did other things as well which I thought were going to be necessary, but I'm not sure they are anymore.~~

~~The 'ready' vs 'hello' change is meh. Could surely be better, nor is it strictly necessary for these changes either (it is helpful for the mode of "don't let the client do things until the host responds", but that could be a change we do generally).~~

Going to integration test this with the hello-world app and multiple clients.

We need to decide what a host making a request looks like, should we race responses, or should we move that functionality to be client-side only?

- [x] ~~Integration test~~ (change is now quite minimal, im confident with unit tests)
- [x] Decide what to do about host requests (rip them out in a different PR)