### PR TITLE
initializing resizer after client has connected

### DIFF
--- a/src/host.js
+++ b/src/host.js
@@ -23,13 +23,14 @@ export default class Host extends Port {
 
 		this.iframe = iframe;
 
-		this.resizer = resizer.iframeResizer({}, iframe);
+		this.resizer = null;
 	}
 	connect() {
 		var me = this;
 		return new Promise((resolve, reject) => {
 			me.onEvent('ready', function() {
 				super.connect();
+				me.resizer = resizer.iframeResizer({}, me.iframe);
 				resolve();
 			}).onEvent('title', function(title) {
 				document.title = title;
@@ -40,8 +41,8 @@ export default class Host extends Port {
 		});
 	}
 	close() {
-		this.resizer.close(this.iframe);
 		super.close();
+		this.resizer.close(this.iframe);
 	}
 	static createIFrame(src) {
 		var iframe = document.createElement('iframe');

--- a/test/host.js
+++ b/test/host.js
@@ -37,7 +37,7 @@ describe('host', () => {
 
 	describe('methods', () => {
 
-		let host, callback, onEvent, sendEventRaw, element, resizerClose;
+		let host, callback, onEvent, sendEventRaw, element;
 
 		beforeEach(() => {
 			global.window = {
@@ -58,21 +58,21 @@ describe('host', () => {
 			host = new Host(() => element, 'http://cdn.com/app/index.html', callback);
 			onEvent = sinon.spy(host, 'onEvent');
 			sendEventRaw = sinon.stub(host, 'sendEventRaw');
-			resizerClose = sinon.stub(host.resizer, 'close');
 		});
 
 		afterEach(() => {
 			onEvent.restore();
 			sendEventRaw.restore();
-			resizerClose.restore();
 		});
 
 		describe('close', () => {
 
 			it('should close resizer', (done) => {
 				host.connect().then(() => {
+					let resizerClose = sinon.stub(host.resizer, 'close');
 					host.close();
 					resizerClose.should.have.been.calledWith(host.iframe);
+					resizerClose.restore();
 					done();
 				});
 				host.receiveEvent('ready');


### PR DESCRIPTION
@rschick: so the iframe-resizer wasn't working for me. The problem was that the host's resizer code was running and firing events down to the client before the client's resizer code had a chance to add its listeners. By initializing the host's resizer after the client has loaded, that solves the issue.

Look OK?