### PR TITLE
fix(response) propogate request errors to the client

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "babel": "^5.6.4",
     "browserify": "^10.2.3",
     "chai": "^3.0.0",
+    "chai-things": "^0.2.0",
     "coveralls": "^2.11.2",
     "gulp": "^3.9.0",
     "gulp-frau-publisher": "^2.2.0",

--- a/src/port.js
+++ b/src/port.js
@@ -152,9 +152,9 @@ export default class Port {
 					e[prop] = sentError.props[prop];
 				}
 
-				req.promise(Promise.reject(e));
+				req.reject(e);
 			} else {
-				req.promise(payload.val);
+				req.resolve(payload.val);
 			}
 
 			requests.splice(i, 1);
@@ -198,7 +198,8 @@ export default class Port {
 					requestType,
 					{
 						id: id,
-						promise: resolve,
+						resolve,
+						reject
 					}
 				);
 			me.sendMessage(`req.${requestType}`,{id: id, args: args});

--- a/src/port.js
+++ b/src/port.js
@@ -240,12 +240,16 @@ export default class Port {
 		var me = this;
 
 		waiting.forEach(function(w) {
-			var handlerResult = handler;
-			if(typeof(handler) === 'function') {
-				handlerResult = handler.apply(handler, w.args);
-			}
 			Promise
-				.resolve(handlerResult)
+				.resolve()
+				.then(() => {
+					if (typeof(handler) === 'function') {
+						return handler.apply(handler, w.args);
+					}
+
+					// otherwise "handler" is a value / Promise
+					return handler;
+				})
 				.then((val) => {
 					me.sendMessage(`res.${requestType}`, { id: w.id, val: val });
 				})

--- a/src/transform-error.js
+++ b/src/transform-error.js
@@ -1,0 +1,83 @@
+export const ERROR_OBJECT_SENTINEL = '_ifrau-error-object';
+
+function deErrorifyArray (input) {
+	const result = input.map(deErrorify);
+	return result;
+}
+
+function errorifyArray (input) {
+	const result = input.map(errorify);
+	return result;
+}
+
+function deErrorifyObject (input) {
+	const isError = input instanceof Error;
+	const result = isError ? { props: {} } : {};
+
+	if (isError) {
+		result.message = input.message;
+		result.name = input.name;
+
+		result[ERROR_OBJECT_SENTINEL] = true;
+	}
+
+	const propTarget = isError ? result.props : result;
+	for (let key of Object.keys(input)) {
+		const prop = deErrorify(input[key]);
+
+		propTarget[key] = prop;
+	}
+
+	return result;
+}
+
+function errorifyObject (input) {
+	const isError = input[ERROR_OBJECT_SENTINEL] === true;
+
+	const result = isError ? new Error(input.message) : {};
+
+	if (isError) {
+		result.name = input.name;
+	}
+
+	const propSource = isError ? input.props : input;
+	for (let key of Object.keys(propSource)) {
+		const prop = errorify(propSource[key]);
+
+		result[key] = prop;
+	}
+
+	return result;
+}
+
+function deErrorify (input) {
+	if (input !== null && typeof input === 'object') {
+		if (Array.isArray(input)) {
+			return deErrorifyArray(input);
+		}
+
+		return deErrorifyObject(input);
+	}
+
+	if (typeof input === 'function') {
+		// Not much to be done here :(
+		return null;
+	}
+
+	return input;
+}
+
+function errorify (input) {
+	if (input !== null && typeof input === 'object') {
+		if (Array.isArray(input)) {
+			return errorifyArray(input);
+		}
+
+		return errorifyObject(input);
+	}
+
+	return input;
+}
+
+export { deErrorify as fromError };
+export { errorify as toError };

--- a/test/port.js
+++ b/test/port.js
@@ -387,29 +387,36 @@ describe('port', () => {
 
 		it('should ignore responses which aren\'t pending', (done) => {
 			var req = {
-				promise: sinon.spy()
+				resolve: sinon.spy(),
+				reject: sinon.spy()
 			};
 			port.pendingRequests.foo = [req];
 			port.receiveRequestResponse('bar', {id: port.requestId});
 			setTimeout(() => {
-				req.promise.should.not.have.been.called; done(); }
-			);
+				req.resolve.should.not.have.been.called;
+				req.reject.should.not.have.been.called;
+				done();
+			});
 		});
 
 		it('should only respond to request with matching id', (done) => {
 			var req1 = {
 				id: 1,
-				promise: sinon.spy()
+				resolve: sinon.spy(),
+				reject: sinon.spy()
 			};
 			var req2 = {
 				id: 2,
-				promise: sinon.spy()
+				resolve: sinon.spy(),
+				reject: sinon.spy()
 			};
 			port.pendingRequests.foo = [req1, req2];
 			port.receiveRequestResponse('foo', {id: 2});
 			setTimeout(() => {
-				req1.promise.should.not.have.been.called;
-				req2.promise.should.have.been.calledOnce;
+				req1.resolve.should.not.have.been.called;
+				req1.reject.should.not.have.been.called;
+				req2.resolve.should.have.been.calledOnce;
+				req2.reject.should.not.have.been.called;
 				done();
 			});
 		});

--- a/test/port.js
+++ b/test/port.js
@@ -737,6 +737,69 @@ describe('port', () => {
 			});
 		});
 
+		it('should propogate error to the client if handler throws', (done) => {
+			function handler () {
+				const e = new TypeError('bad things');
+				e.someProp = 'moo';
+				throw e;
+			}
+
+			const reqType = 'bar';
+			port.requestHandlers[reqType] = handler;
+			port.waitingRequests[reqType] = [{ id: 1, args: [] }];
+
+			port.sendRequestResponse(reqType);
+
+			setTimeout(() => {
+				sendMessage.should.have.been.calledWith(
+					'res.bar',
+					{
+						id: 1,
+						err: {
+							name: 'TypeError',
+							message: 'bad things',
+							props: {
+								someProp: 'moo'
+							}
+						}
+					}
+				);
+
+				done();
+			});
+		});
+
+		it('should propogate error to the client if handler returns rejected Promise', (done) => {
+			function handler () {
+				const e = new TypeError('bad things');
+				e.someProp = 'moo';
+				return Promise.reject(e);
+			}
+
+			const reqType = 'bar';
+			port.requestHandlers[reqType] = handler;
+			port.waitingRequests[reqType] = [{ id: 1, args: [] }];
+
+			port.sendRequestResponse(reqType);
+
+			setTimeout(() => {
+				sendMessage.should.have.been.calledWith(
+					'res.bar',
+					{
+						id: 1,
+						err: {
+							name: 'TypeError',
+							message: 'bad things',
+							props: {
+								someProp: 'moo'
+							}
+						}
+					}
+				);
+
+				done();
+			});
+		});
 	});
 
 	describe('validateEvent', () => {

--- a/test/transform-error.js
+++ b/test/transform-error.js
@@ -1,0 +1,109 @@
+import { default as chai, expect } from 'chai';
+import things from 'chai-things';
+import sinon from 'sinon';
+
+chai.use(things);
+
+import { fromError, toError, ERROR_OBJECT_SENTINEL } from '../src/transform-error';
+
+describe('transform-error', () => {
+	describe('fromError', () => {
+		it('should translate an Error into a cloneable object', () => {
+			const err = new TypeError('bad things');
+			const obj = fromError(err);
+
+			expect(obj).to.be.an('object');
+			expect(obj).to.have.a.property('name').that.equals('TypeError');
+			expect(obj).to.have.a.property('message').that.equals('bad things');
+			expect(obj).to.have.a.property(ERROR_OBJECT_SENTINEL);
+		});
+
+		it('should translate an array of Errors into cloneable objects', () => {
+			const errs = [new TypeError('bad things'), new Error('other bad things')];
+			const objs = fromError(errs);
+
+			expect(objs).to.be.an.instanceof(Array);
+			expect(objs).to.have.length(errs.length);
+			expect(objs).to.all.have.a.property(ERROR_OBJECT_SENTINEL);
+		});
+
+		describe('properties', () => {
+			it('should copy properties of the Error/object into a "props" field', () => {
+				const err = new Error('bad things');
+				err.foo = 'bar';
+				err.nul = null;
+				err.arr = ['bar'];
+				err.obj = { foo: 'bar' };
+
+				const obj = fromError(err);
+
+				expect(obj).to.have.a.property('props').that.is.an('object');
+				expect(obj.props).to.have.a.property('foo').that.equals(err.foo);
+				expect(obj.props).to.have.a.property('nul').that.equals(err.nul);
+				expect(obj.props).to.have.a.property('arr').that.deep.equals(err.arr);
+				expect(obj.props).to.have.a.property('obj').that.deep.equals(err.obj);
+			});
+
+			it('should copy Function properties as null (sad)', () => {
+				const input = {
+					fn: () => {}
+				};
+
+				const obj = fromError(input);
+				expect(obj).to.have.a.property('fn').that.is.null;
+			});
+
+			it('should transform Error properties', () => {
+				const err = new Error('bad things');
+				err.err = new TypeError('other bad things');
+				err.err.err = new Error('more bad things');
+
+				const obj = fromError(err);
+
+				expect(obj)
+					.to.be.an('object')
+					.that.has.a.property(ERROR_OBJECT_SENTINEL);
+				expect(obj)
+					.to.have.a.property('props')
+						.that.is.an('object')
+						.that.has.a.property('err')
+							.that.is.an('object')
+							.that.has.a.property(ERROR_OBJECT_SENTINEL);
+				expect(obj.props.err)
+					.to.have.a.property('props')
+						.that.is.an('object')
+						.that.has.a.property('err')
+							.that.is.an('object')
+							.that.has.a.property(ERROR_OBJECT_SENTINEL);
+			});
+		});
+	});
+
+	describe('toError', () => {
+		it('should approximately invert fromError', () => {
+			const input = new TypeError('foo');
+			input.foo = 'bar';
+			input.nul = null;
+			input.fn = () => {};
+			input.arr = ['bar'];
+			input.obj = { foo: 'bar' };
+			input.err = new Error('bar');
+
+			const err = toError(fromError(input));
+
+			expect(err).to.be.an.instanceof(Error);
+			expect(err).to.have.a.property('name').that.equals('TypeError');
+			expect(err).to.have.a.property('message').that.equals('foo');
+			expect(err).to.have.a.property('foo').that.equals(input.foo);
+			expect(err).to.have.a.property('nul').that.equals(input.nul);
+			expect(err).to.have.a.property('fn').that.is.null;
+			expect(err).to.have.a.property('arr').that.deep.equals(input.arr);
+			expect(err).to.have.a.property('obj').that.deep.equals(input.obj);
+			expect(err)
+				.to.have.a.property('err')
+					.that.is.an.instanceof(Error)
+					.and.has.a.property('message')
+						.that.equals('bar');
+		});
+	});
+});


### PR DESCRIPTION
I'm currently using the same key, but switching the key prefix to _resErr_ or something might be better for backwards compat (so old clients wouldn't process the unexpected response)?

- [x] unit tests
- [x] actually try running the code