### PR TITLE
implementing an event queue for events fired before connection handshake

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -13,7 +13,7 @@ export default class Client extends Port {
 		return new Promise((resolve, reject) => {
 
 			me.open();
-			me.sendEventRaw('ready');
+			me.sendMessage('evt.ready');
 
 			super.connect();
 			resolve();

--- a/test/client.js
+++ b/test/client.js
@@ -9,7 +9,7 @@ import Client from '../src/client';
 
 describe('client', () => {
 
-	var client, callback, sendEvent, sendEventRaw, clock;
+	var client, callback, sendEvent, sendMessage, clock;
 
 	beforeEach(() => {
 		global.window = {
@@ -25,13 +25,13 @@ describe('client', () => {
 		};
 		client = new Client();
 		sendEvent = sinon.stub(client, 'sendEvent');
-		sendEventRaw = sinon.stub(client, 'sendEventRaw');
+		sendMessage = sinon.stub(client, 'sendMessage');
 		clock = sinon.useFakeTimers();
 	});
 
 	afterEach(() => {
 		sendEvent.restore();
-		sendEventRaw.restore();
+		sendMessage.restore();
 		clock.restore();
 	});
 
@@ -60,7 +60,7 @@ describe('client', () => {
 
 		it('should send the "ready" event', () => {
 			client.connect();
-			sendEventRaw.should.have.been.calledWith('ready');
+			sendMessage.should.have.been.calledWith('evt.ready');
 		});
 
 	});

--- a/test/host.js
+++ b/test/host.js
@@ -64,7 +64,7 @@ describe('host', () => {
 
 	describe('methods', () => {
 
-		let host, callback, onEvent, sendEventRaw;
+		let host, callback, onEvent, sendEvent;
 
 		beforeEach(() => {
 			global.window.addEventListener = sinon.stub();
@@ -76,12 +76,12 @@ describe('host', () => {
 			callback = sinon.spy();
 			host = new Host(() => element, 'http://cdn.com/app/index.html', callback);
 			onEvent = sinon.spy(host, 'onEvent');
-			sendEventRaw = sinon.stub(host, 'sendEventRaw');
+			sendEvent = sinon.stub(host, 'sendEvent');
 		});
 
 		afterEach(() => {
 			onEvent.restore();
-			sendEventRaw.restore();
+			sendEvent.restore();
 		});
 
 		describe('close', () => {

--- a/test/port.js
+++ b/test/port.js
@@ -615,10 +615,15 @@ describe('port', () => {
 			sendMessage.restore();
 		});
 
-		it('should throw if not connected', () => {
-			expect(() => {
-				port.sendEvent('foo', 'bar');
-			}).to.throw(Error, 'Cannot sendEvent() before connect() has completed');
+		it('should queue if not connected', () => {
+			port.sendEvent('foo', 'bar');
+			sendMessage.should.not.have.been.called;
+			expect(port.eventQueue.length).to.equal(1);
+		});
+
+		it('should send queued messages after connect', () => {
+			port.sendEvent('foo', 'bar').connect();
+			sendMessage.should.have.been.calledWith('evt.foo', ['bar']);
 		});
 
 		it('should "sendMessage" prepended with "evt"', () => {


### PR DESCRIPTION
Review: @omsmith, @dbatiste 

This will allow plugins to fire events *before* the call to `connect()` occurs. Once the connection handshake happens, all the events in the queue will get sent.

As @dbatiste suggested, I'd eventually like to do this with requests and services as well.