### PR TITLE
title sync plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint:test": "jshint test/*.js",
     "prepublish:cdn": "npm run browserify",
     "publish:cdn": "gulp publish",
-    "test:unit": "istanbul cover _mocha -- test/*.js",
+    "test:unit": "istanbul cover _mocha -- --recursive",
     "test": "npm run lint -s && npm run test:unit -s",
     "pretranspile": "rimraf lib",
     "transpile": "babel src --optional runtime --out-dir lib",

--- a/src/client.js
+++ b/src/client.js
@@ -1,11 +1,18 @@
 import Port from './port';
+import {clientSyncTitle} from './plugins/sync-title';
 
 export default class Client extends Port {
 	constructor(options) {
 
+		options = options || {};
+
 		super(window.parent, '*', options);
 
 		this.lastHeight = 0;
+
+		if(options.syncTitle !== false) {
+			this.use(clientSyncTitle);
+		}
 
 	}
 	connect() {
@@ -22,8 +29,5 @@ export default class Client extends Port {
 	}
 	navigate(url) {
 		this.sendEvent('navigate', url);
-	}
-	setTitle(title) {
-		this.sendEvent('title', title);
 	}
 }

--- a/src/host.js
+++ b/src/host.js
@@ -1,10 +1,13 @@
 import Port from './port';
 import {default as resizer} from 'iframe-resizer';
+import {hostSyncTitle} from './plugins/sync-title';
 
 var originRe = /^(http:\/\/|https:\/\/)[^\/]+/i;
 
 export default class Host extends Port {
 	constructor(elementProvider, src, options) {
+
+		options = options || {};
 
 		var origin = Host.tryGetOrigin(src);
 		if(origin === null) {
@@ -22,6 +25,9 @@ export default class Host extends Port {
 		super(iframe.contentWindow, origin, options);
 
 		this.iframe = iframe;
+
+		this.use(hostSyncTitle({page: options.syncPageTitle ? true : false}));
+
 	}
 	connect() {
 		var me = this;
@@ -35,8 +41,6 @@ export default class Host extends Port {
 					me.iframe
 				);
 				resolve();
-			}).onEvent('title', function(title) {
-				document.title = title;
 			}).onEvent('navigate', function(url) {
 				document.location.href = url;
 			});

--- a/src/plugins/sync-title.js
+++ b/src/plugins/sync-title.js
@@ -1,0 +1,62 @@
+function installClientPolling(sync) {
+
+	let title = '';
+
+	setInterval(() => {
+		let newTitle = document.title;
+		if(newTitle !== title) {
+			title = newTitle;
+			sync(title);
+		}
+	}, 100);
+
+}
+
+function installClientMutation(sync) {
+
+	let elem = document.querySelector('title');
+	if(elem === null) {
+		elem = document.createElement('title');
+		document.getElementsByTagName('head')[0].appendChild(elem);
+	}
+	sync(document.title);
+
+	const observer = new window.MutationObserver(function(mutations) {
+		sync(mutations[0].target.textContent);
+	});
+	observer.observe(
+		elem,
+		{ subtree: true, characterData: true, childList: true}
+	);
+
+}
+
+function clientSyncTitle(client) {
+
+	function sync(value) {
+		client.sendEvent('title', value);
+	}
+
+	if('MutationObserver' in window) {
+		installClientMutation(sync);
+	} else {
+		installClientPolling(sync);
+	}
+}
+
+function hostSyncTitle(options) {
+	options = options || {};
+	return function(host) {
+		host.onEvent('title', function(title) {
+			if(options.page) {
+				document.title = title;
+			}
+			if(host.iframe) {
+				host.iframe.title = title;
+			}
+		});
+	};
+}
+
+export {clientSyncTitle};
+export {hostSyncTitle};

--- a/test/client.js
+++ b/test/client.js
@@ -23,7 +23,7 @@ describe('client', () => {
 				scrollHeight: 100
 			}
 		};
-		client = new Client();
+		client = new Client({syncTitle: false});
 		sendEvent = sinon.stub(client, 'sendEvent');
 		sendMessage = sinon.stub(client, 'sendMessage');
 		clock = sinon.useFakeTimers();
@@ -71,18 +71,6 @@ describe('client', () => {
 			client.connect().then(() => {
 				client.navigate('some-url');
 				sendEvent.should.have.been.calledWith('navigate', 'some-url');
-				done();
-			});
-		});
-
-	});
-
-	describe('setTitle', () => {
-
-		it('should fire "title" event', (done) => {
-			client.connect().then(() => {
-				client.setTitle('my title');
-				sendEvent.should.have.been.calledWith('title', 'my title');
 				done();
 			});
 		});

--- a/test/host.js
+++ b/test/host.js
@@ -119,17 +119,11 @@ describe('host', () => {
 				host.receiveEvent('ready');
 			});
 
-			['ready', 'title', 'navigate'].forEach((evt) => {
+			['ready', 'navigate'].forEach((evt) => {
 				it(`should register for the "${evt}" event`, () => {
 					host.connect();
 					onEvent.should.have.been.calledWith(evt);
 				});
-			});
-
-			it('should update the document title', () => {
-				host.connect();
-				host.receiveEvent('title', ['new title']);
-				global.document.title.should.equal('new title');
 			});
 
 			it('should update the document location', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -27,7 +27,7 @@ describe('ifrau', () => {
 	});
 
 	it('should export Client', () => {
-		var client = new Client();
+		var client = new Client({syncTitle: false});
 		expect(client).to.be.defined;
 	});
 

--- a/test/plugins/sync-title.js
+++ b/test/plugins/sync-title.js
@@ -1,0 +1,166 @@
+var chai = require('chai'),
+	expect = chai.expect,
+	sinon = require('sinon');
+
+chai.should();
+chai.use(require('sinon-chai'));
+
+import { clientSyncTitle, hostSyncTitle } from '../../src/plugins/sync-title';
+
+let mutationCallback = null;
+let MockMutationObserver = function(cb) {
+	mutationCallback = cb;
+};
+MockMutationObserver.prototype.observe = function() {};
+
+let MockClient = function() {};
+MockClient.prototype.sendEvent = function() {};
+
+let onEventCallback = null;
+let MockHost = function() {};
+MockHost.prototype.onEvent = function(evt, cb) {
+	onEventCallback = cb;
+};
+
+describe('sync-title', () => {
+
+	beforeEach(() => {
+		global.document = {
+			title: 'init title'
+		};
+	});
+
+	describe('client', () => {
+
+		var client, sendEvent;
+
+		beforeEach(() => {
+			global.window = {};
+			client = new MockClient();
+			sendEvent = sinon.stub(client, 'sendEvent');
+		});
+
+		afterEach(() => {
+			sendEvent.restore();
+		});
+
+		describe('mutation-observer', () => {
+
+			var createElement;
+
+			beforeEach(() => {
+				createElement = sinon.spy();
+				global.window.MutationObserver = MockMutationObserver;
+				global.document.createElement = createElement;
+				global.document.getElementsByTagName = sinon.stub().returns([
+					{
+						appendChild: sinon.stub()
+					}
+				]);
+				global.document.querySelector = sinon.stub().returns({});
+				mutationCallback = null;
+			});
+
+			it('should create a title element if it is missing', () => {
+				global.document.querySelector.returns(null);
+				clientSyncTitle(client);
+				createElement.should.have.been.calledWith('title');
+			});
+
+			it('should initially sync page title', () => {
+				clientSyncTitle(client);
+				sendEvent.should.have.been.calledWith('title', 'init title');
+			});
+
+			it('should sync with first mutation textContent', () => {
+				var mutations = [{target: { textContent: 'new title' } }];
+				clientSyncTitle(client);
+				mutationCallback(mutations);
+				sendEvent.should.have.been.calledWith('title', 'new title');
+			});
+
+		});
+
+		describe('polling-observer', () => {
+
+			var clock;
+
+			beforeEach(() => {
+				clock = sinon.useFakeTimers();
+			});
+
+			afterEach(() => {
+				clock.restore();
+			});
+
+			it('should sync after 100ms', () => {
+				clientSyncTitle(client);
+				clock.tick(100);
+				sendEvent.should.have.been.calledWith('title', 'init title');
+			});
+
+			it('should not sync if title remains the same', () => {
+				clientSyncTitle(client);
+				clock.tick(200);
+				sendEvent.should.have.been.calledOnce;
+			});
+
+			it('should sync if title changes', () => {
+				clientSyncTitle(client);
+				clock.tick(100);
+				global.document.title = 'new title';
+				clock.tick(100);
+				sendEvent.should.have.been.calledWith('title', 'new title');
+			});
+
+		});
+
+	});
+
+	describe('host', () => {
+
+		var host, onEvent;
+
+		beforeEach(() => {
+			host = new MockHost();
+			onEvent = sinon.spy(host, 'onEvent');
+			onEventCallback = null;
+		});
+
+		afterEach(() => {
+			onEvent.restore();
+		});
+
+		it('should add handler for "title" event', () => {
+			hostSyncTitle()(host);
+			onEvent.should.have.been.calledWith('title');
+		});
+
+		it('should set page title when event fires', () => {
+			hostSyncTitle({page: true})(host);
+			onEventCallback('new title');
+			expect(global.document.title).to.equal('new title');
+		});
+
+		it('should not set page title when option is off', () => {
+			hostSyncTitle({page: false})(host);
+			onEventCallback('new title');
+			expect(global.document.title).to.equal('init title');
+		});
+
+		it('should not set iframe title if undefined', () => {
+			hostSyncTitle()(host);
+			onEventCallback('new title');
+			expect(host.iframe).to.not.be.defined;
+		});
+
+		it('should set iframe title if defined', () => {
+			host.iframe = {};
+			hostSyncTitle()(host);
+			onEventCallback('new title');
+			expect(host.iframe.title).to.equal('new title');
+		});
+
+	});
+
+});


### PR DESCRIPTION
@omsmith, @dbatiste: let me know what you think!

This plugin replaces the existing `setTitle` method on the client and moves handling of the `title` event into the plugin itself. The plugin installs a mutation observer in the client which watches for changes to the page title and sends them up to the host. If mutation events aren't available (IE10), it polls every `100ms`. When the host receives the event, it sets the document title as it did before, but also sets the title of the IFRAME itself. This will be better for accessibility.

There's an option on the client called `syncTitle` to disable this behaviour. It's `true` by default.

There's an option on the host called `syncPageTitle` to disable page title syncing, it's `false` by default. There's currently no way to disable IFRAME title syncing on the host, but we could add it in the future (`syncFrameTitle`) if we saw a case where you wouldn't want it.