### PR TITLE
lang plugin

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -1,4 +1,5 @@
 import Port from './port';
+import {clientSyncLang} from './plugins/sync-lang';
 import {clientSyncTitle} from './plugins/sync-title';
 
 export default class Client extends Port {
@@ -8,6 +9,9 @@ export default class Client extends Port {
 
 		super(window.parent, '*', options);
 
+		if(options.syncLang) {
+			this.use(clientSyncLang);
+		}
 		if(options.syncTitle !== false) {
 			this.use(clientSyncTitle);
 		}

--- a/src/host.js
+++ b/src/host.js
@@ -1,5 +1,6 @@
 import Port from './port';
 import {default as resizer} from './plugins/iframe-resizer';
+import {hostSyncLang} from './plugins/sync-lang';
 import {hostSyncTitle} from './plugins/sync-title';
 
 var originRe = /^(http:\/\/|https:\/\/)[^\/]+/i;
@@ -26,6 +27,9 @@ export default class Host extends Port {
 
 		this.iframe = iframe;
 
+		if(options.syncLang) {
+			this.use(hostSyncLang);
+		}
 		this.use(hostSyncTitle({page: options.syncPageTitle ? true : false}));
 		if(options.resizeFrame !== false) {
 			this.use(resizer);

--- a/src/plugins/sync-lang.js
+++ b/src/plugins/sync-lang.js
@@ -1,0 +1,24 @@
+export function clientSyncLang(client) {
+	return client.request('lang').then((lang) => {
+		var htmlElem = document.getElementsByTagName('html')[0];
+		htmlElem.setAttribute('lang', lang.lang);
+		if(lang.fallback) {
+			htmlElem.setAttribute('data-lang-default', lang.fallback);
+		}
+		if(lang.isRtl) {
+			document.body.dir = 'rtl';
+		}
+	});
+}
+
+export function hostSyncLang(host) {
+	host.onRequest('lang', () => {
+		var htmlElem = document.getElementsByTagName('html')[0];
+		var isRtl = (document.body.dir.toLowerCase() === 'rtl');
+		return {
+			isRtl: isRtl,
+			lang: htmlElem.getAttribute('lang'),
+			fallback: htmlElem.getAttribute('data-lang-default')
+		};
+	});
+}

--- a/test/plugins/sync-lang.js
+++ b/test/plugins/sync-lang.js
@@ -1,0 +1,133 @@
+var chai = require('chai'),
+	expect = chai.expect,
+	sinon = require('sinon');
+
+chai.should();
+chai.use(require('sinon-chai'));
+
+import { clientSyncLang, hostSyncLang } from '../../src/plugins/sync-lang';
+
+let MockClient = function() {};
+MockClient.prototype.request = function() {};
+
+let MockHost = function() {};
+MockHost.prototype.onRequest = function() {};
+
+describe('sync-lang', () => {
+
+	var setAttribute, getAttribute;
+
+	beforeEach(() => {
+		setAttribute = sinon.stub();
+		getAttribute = sinon.stub();
+		global.document = {
+			body: { dir: '' },
+			getElementsByTagName: function() {
+				return [{
+					getAttribute: getAttribute,
+					setAttribute: setAttribute
+				}];
+			}
+		};
+	});
+
+	describe('client', () => {
+
+		var client, request;
+
+		beforeEach(() => {
+			client = new MockClient();
+			request = sinon.stub(client, 'request');
+		});
+
+		afterEach(() => {
+			request.restore();
+		});
+
+		it('should request for "lang"', () => {
+			request.returns(new Promise(() => {}));
+			clientSyncLang(client);
+			request.should.have.been.calledWith('lang');
+		});
+
+		it('should apply langTag to HTML element', (done) => {
+			request.returns(new Promise((resolve) => {
+				resolve({lang: 'ab-CD'});
+			}));
+			clientSyncLang(client).then(() => {
+				setAttribute.should.have.been.calledWith('lang', 'ab-CD');
+				done();
+			});
+		});
+
+		it('should apply fallback to HTML element', (done) => {
+			request.returns(new Promise((resolve) => {
+				resolve({fallback: 'ef-GH'});
+			}));
+			clientSyncLang(client).then(() => {
+				setAttribute.should.have.been.calledWith('data-lang-default', 'ef-GH');
+				done();
+			});
+		});
+
+		it('should set RTL direction on body', (done) => {
+			request.returns(new Promise((resolve) => {
+				resolve({isRtl: true});
+			}));
+			clientSyncLang(client).then(() => {
+				expect(document.body.dir).to.equal('rtl');
+				done();
+			});
+		});
+
+	});
+
+	describe('host', () => {
+
+		var host, onRequest;
+
+		beforeEach(() => {
+			host = new MockHost();
+			onRequest = sinon.spy(host, 'onRequest');
+		});
+
+		afterEach(() => {
+			onRequest.restore();
+		});
+
+		it('should add request handler for "lang"', () => {
+			hostSyncLang(host);
+			onRequest.should.have.been.calledWith('lang');
+		});
+
+		it('should return lang attribute from HTML element', () => {
+			getAttribute.withArgs('lang').returns('ab-CD');
+			hostSyncLang(host);
+			const value = onRequest.args[0][1]();
+			expect(value.lang).to.equal('ab-CD');
+		});
+
+		it('should return data-lang-default attribute from HTML element', () => {
+			getAttribute.withArgs('data-lang-default').returns('ef-GH');
+			hostSyncLang(host);
+			const value = onRequest.args[0][1]();
+			expect(value.fallback).to.equal('ef-GH');
+		});
+
+		it('should be RTL body direction is RTL', () => {
+			global.document.body.dir = 'RtL';
+			hostSyncLang(host);
+			const value = onRequest.args[0][1]();
+			expect(value.isRtl).to.be.true;
+		});
+
+		it('should not be RTL body direction is not RTL', () => {
+			global.document.body.dir = 'abc';
+			hostSyncLang(host);
+			const value = onRequest.args[0][1]();
+			expect(value.isRtl).to.be.false;
+		});
+
+	});
+
+});


### PR DESCRIPTION
Plugin which automatically syncs the host's language (langTag, fallback and isRtl) with the client. This will enable `frau-locale-provider` to act normally within the client (not rely on ifrau itself).