### PR TITLE
remove-navigate-event

### DIFF
--- a/src/host.js
+++ b/src/host.js
@@ -46,8 +46,6 @@ export default class Host extends Port {
 			me.onEvent('ready', function() {
 				super.connect();
 				resolve();
-			}).onEvent('navigate', function(url) {
-				document.location.href = url;
 			});
 			super.open();
 		});

--- a/test/host.js
+++ b/test/host.js
@@ -102,17 +102,9 @@ describe('host', () => {
 				host.receiveEvent('ready');
 			});
 
-			['ready', 'navigate'].forEach((evt) => {
-				it(`should register for the "${evt}" event`, () => {
-					host.connect();
-					onEvent.should.have.been.calledWith(evt);
-				});
-			});
-
-			it('should update the document location', () => {
+			it(`should register for the "ready" event`, () => {
 				host.connect();
-				host.receiveEvent('navigate', ['new url']);
-				global.document.location.href.should.equal('new url');
+				onEvent.should.have.been.calledWith('ready');
 			});
 
 		});


### PR DESCRIPTION
removing "navigate" event as it's been replaced by the navigation service in Brightspace