### PR TITLE
(refact) Move back to ES5

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "ifrau",
   "version": "0.10.1",
   "description": "Free-range app utility for IFRAME-based FRAs",
-  "main": "lib/index.js",
+  "main": "src/index.js",
   "scripts": {
-    "prebrowserify": "rimraf dist && mkdir dist && npm run transpile",
-    "browserify": "browserify -g uglifyify -s ifrau ./lib/index.js > ./dist/ifrau.js",
+    "prebrowserify": "rimraf dist && mkdir dist",
+    "browserify": "browserify -g uglifyify -s ifrau ./src/index.js > ./dist/ifrau.js",
     "lint": "npm run lint:src && npm run lint:test",
     "lint:src": "jshint src",
     "lint:test": "jshint test",
@@ -13,8 +13,6 @@
     "publish:cdn": "gulp publish",
     "test:unit": "istanbul cover node_modules/mocha/bin/_mocha -- --recursive",
     "test": "npm run lint -s && npm run test:unit -s",
-    "pretranspile": "rimraf lib",
-    "transpile": "babel src --optional runtime --out-dir lib",
     "report-coverage": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage"
   },
   "repository": {
@@ -34,12 +32,13 @@
   },
   "homepage": "https://github.com/Brightspace/ifrau",
   "dependencies": {
-    "babel-runtime": "^5.5.8",
     "iframe-resizer": "^3.0.0",
+    "inherits": "^2.0.1",
+    "lie": "^3.0.1",
     "uuid": "^2.0.1"
   },
   "devDependencies": {
-    "babel": "^5.6.4",
+    "babel": "^5.8.23",
     "browserify": "^10.2.3",
     "chai": "^3.0.0",
     "chai-things": "^0.2.0",

--- a/src/.jshintrc
+++ b/src/.jshintrc
@@ -1,4 +1,4 @@
 {
 	"browser": true,
-	"esnext": true
+	"node": true
 }

--- a/src/client.js
+++ b/src/client.js
@@ -1,40 +1,49 @@
-import Port from './port';
-import {clientSyncLang} from './plugins/sync-lang';
-import {clientSyncTitle} from './plugins/sync-title';
-import {clientSyncFont} from './plugins/sync-font';
+'use strict';
 
-export default class Client extends Port {
-	constructor(options) {
+var inherits = require('inherits'),
+	Promise = require('lie');
 
-		options = options || {};
+var Port = require('./port'),
+	syncLang = require('./plugins/sync-lang').client,
+	syncTitle = require('./plugins/sync-title').client,
+	syncFont = require('./plugins/sync-font').client;
 
-		super(window.parent, '*', options);
-
-		if(options.syncLang) {
-			this.use(clientSyncLang);
-		}
-		if(options.syncTitle !== false) {
-			this.use(clientSyncTitle);
-		}
-		if(options.syncFont) {
-			this.use(clientSyncFont);
-		}
-
+function Client (options) {
+	if (!(this instanceof Client)) {
+		return new Client(options);
 	}
-	connect() {
-		var me = this;
-		return new Promise((resolve, reject) => {
 
-			me.open();
-			me.sendMessage('evt.ready');
+	options = options || {};
 
-			super.connect();
+	Port.call(this, window.parent, '*', options);
 
-			resolve(me);
-
-		});
+	if(options.syncLang) {
+		this.use(syncLang);
 	}
-	navigate(url) {
-		this.sendEvent('navigate', url);
+	if(options.syncTitle !== false) {
+		this.use(syncTitle);
+	}
+	if(options.syncFont) {
+		this.use(syncFont);
 	}
 }
+inherits(Client, Port);
+
+Client.prototype.connect = function connect() {
+	var me = this;
+
+	return new Promise(function(resolve/*, reject*/) {
+		me.open();
+		me.sendMessage('evt.ready');
+
+		Port.prototype.connect.call(me);
+
+		resolve(me);
+	});
+};
+
+Client.prototype.navigate = function navigate(url) {
+	this.sendEvent('navigate', url);
+};
+
+module.exports = Client;

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,4 @@
-export {default as Host} from './host';
-export {default as Client} from './client';
+'use strict';
+
+module.exports.Client = require('./client');
+module.exports.Host = require('./host');

--- a/src/plugins/iframe-resizer.js
+++ b/src/plugins/iframe-resizer.js
@@ -1,6 +1,8 @@
-import {default as iframeResizer} from 'iframe-resizer';
+'use strict';
 
-export default function resizer(host) {
+var iframeResizer = require('iframe-resizer');
+
+module.exports.host = function resizer(host) {
 	var initialized = false;
 	host.onEvent('ready', function() {
 		if(initialized) {
@@ -19,4 +21,4 @@ export default function resizer(host) {
 			host.iframe.iFrameResizer.close(host.iframe);
 		}
 	});
-}
+};

--- a/src/plugins/sync-font.js
+++ b/src/plugins/sync-font.js
@@ -1,16 +1,18 @@
-export function clientSyncFont(client) {
-	return client.request('font').then((font) => {
+'use strict';
+
+module.exports.client = function clientSyncFont(client) {
+	return client.request('font').then(function(font) {
 		document.body.style.fontFamily = font.family;
 		document.body.style.fontSize= font.size;
 	});
-}
+};
 
-export function hostSyncFont(host) {
-	host.onRequest('font', () => {
-		const computedStyle = window.getComputedStyle(document.body);
+module.exports.host = function hostSyncFont(host) {
+	host.onRequest('font', function() {
+		var computedStyle = window.getComputedStyle(document.body);
 		return {
 			family: computedStyle.fontFamily,
 			size: computedStyle.fontSize
 		};
 	});
-}
+};

--- a/src/plugins/sync-lang.js
+++ b/src/plugins/sync-lang.js
@@ -1,5 +1,7 @@
-export function clientSyncLang(client) {
-	return client.request('lang').then((lang) => {
+'use strict';
+
+module.exports.client = function clientSyncLang(client) {
+	return client.request('lang').then(function(lang) {
 		var htmlElem = document.getElementsByTagName('html')[0];
 		htmlElem.setAttribute('lang', lang.lang);
 		if(lang.fallback) {
@@ -9,10 +11,10 @@ export function clientSyncLang(client) {
 			document.body.dir = 'rtl';
 		}
 	});
-}
+};
 
-export function hostSyncLang(host) {
-	host.onRequest('lang', () => {
+module.exports.host = function hostSyncLang(host) {
+	host.onRequest('lang', function() {
 		var htmlElem = document.getElementsByTagName('html')[0];
 		var isRtl = (document.body.dir.toLowerCase() === 'rtl');
 		return {
@@ -21,4 +23,4 @@ export function hostSyncLang(host) {
 			fallback: htmlElem.getAttribute('data-lang-default')
 		};
 	});
-}
+};

--- a/src/plugins/sync-title.js
+++ b/src/plugins/sync-title.js
@@ -1,9 +1,9 @@
 function installClientPolling(sync) {
 
-	let title = '';
+	var title = '';
 
-	setInterval(() => {
-		let newTitle = document.title;
+	setInterval(function() {
+		var newTitle = document.title;
 		if(newTitle !== title) {
 			title = newTitle;
 			sync(title);
@@ -14,14 +14,14 @@ function installClientPolling(sync) {
 
 function installClientMutation(sync) {
 
-	let elem = document.querySelector('title');
+	var elem = document.querySelector('title');
 	if(elem === null) {
 		elem = document.createElement('title');
 		document.getElementsByTagName('head')[0].appendChild(elem);
 	}
 	sync(document.title);
 
-	const observer = new window.MutationObserver(function(mutations) {
+	var observer = new window.MutationObserver(function(mutations) {
 		sync(mutations[0].target.textContent);
 	});
 	observer.observe(
@@ -31,7 +31,7 @@ function installClientMutation(sync) {
 
 }
 
-function clientSyncTitle(client) {
+module.exports.client = function clientSyncTitle(client) {
 
 	function sync(value) {
 		client.sendEvent('title', value);
@@ -42,9 +42,9 @@ function clientSyncTitle(client) {
 	} else {
 		installClientPolling(sync);
 	}
-}
+};
 
-function hostSyncTitle(options) {
+module.exports.host = function hostSyncTitle(options) {
 	options = options || {};
 	return function(host) {
 		host.onEvent('title', function(title) {
@@ -56,7 +56,4 @@ function hostSyncTitle(options) {
 			}
 		});
 	};
-}
-
-export {clientSyncTitle};
-export {hostSyncTitle};
+};

--- a/src/port.js
+++ b/src/port.js
@@ -1,283 +1,309 @@
-import uuid from 'uuid';
+'use strict';
 
-import { fromError, toError } from './transform-error';
+var Promise = require('lie'),
+	uuid = require('uuid');
 
-let typeNameValidator = /^[a-zA-Z]+[a-zA-Z\-]*$/;
+var fromError = require('./transform-error').fromError,
+	toError = require('./transform-error').toError;
 
-export default class Port {
-	constructor(endpoint, targetOrigin, options) {
-		options = options || {};
-		this.connectQueue = [];
-		this.debugEnabled = options.debug || false;
-		this.endpoint = endpoint;
-		this.eventHandlers = {};
-		this.isConnected = false;
-		this.isOpen = false;
-		this.onCloseCallbacks = [];
-		this.pendingRequests = {};
-		this.requestHandlers = {};
-		this.services = {};
-		this.targetOrigin = targetOrigin;
-		this.waitingRequests = [];
+var typeNameValidator = /^[a-zA-Z]+[a-zA-Z\-]*$/;
 
-		this.id = uuid();
-		this.requestCounter = 0;
+function Port(endpoint, targetOrigin, options) {
+	if (!(this instanceof Port)) {
+		return new Port(endpoint, targetOrigin, options);
 	}
-	close() {
-		if(!this.isOpen) {
-			throw new Error('Port cannot be closed, call open() first');
-		}
-		this.isOpen = false;
-		this.isConnected = false;
-		window.removeEventListener('message', this.receiveMessage);
-		this.onCloseCallbacks.forEach((cb) => cb());
-		this.debug('closed');
-	}
-	connect() {
-		this.isConnected = true;
-		this.debug('connected');
-		this.connectQueue.forEach((func) => func());
-		this.connectQueue = [];
-		return this;
-	}
-	debug(msg) {
-		if(this.debugEnabled) {
-			console.log(msg);
-		}
-	}
-	getService(serviceType, version) {
-		if(!this.isConnected) {
-			throw new Error('Cannot getService() before connect() has completed');
-		}
-		let serviceVersionPrefix = `service:${serviceType}:${version}`;
-		let me = this;
-		function createProxyMethod(name) {
-			return function() {
-				let args = [`${serviceVersionPrefix}:${name}`];
-				for(let i=0; i<arguments.length; i++) {
-					args.push(arguments[i]);
-				}
-				return me.request.apply(me, args);
-			};
-		}
-		function createProxy(methodNames) {
-			let proxy = {};
-			methodNames.forEach((name) => {
-				proxy[name] = createProxyMethod(name);
-			});
-			return proxy;
-		}
-		return me.request(serviceVersionPrefix).then(createProxy);
-	}
-	initHashArrAndPush(dic, key, obj) {
-		if(dic[key] === undefined ) {
-			dic[key] = [];
-		}
-		dic[key].push(obj);
-	}
-	onClose(cb) {
-		this.onCloseCallbacks.push(cb);
-	}
-	onEvent(eventType, handler) {
-		this.debug(`onEvent handler added for "${eventType}"`);
-		if(this.isConnected) {
-			this.debug('You\'ve attached event handlers after connecting, you may have missed some events');
-		}
-		this.initHashArrAndPush(this.eventHandlers, eventType, handler);
-		return this;
-	}
-	onRequest(requestType, handler) {
-		if(this.isConnected) {
-			throw new Error('Add request handlers before connecting');
-		}
-		if(this.requestHandlers[requestType] !== undefined) {
-			throw new Error(`Duplicate onRequest handler for type "${requestType}"`);
-		}
-		this.debug(`onRequest handler added for "${requestType}"`);
-		this.requestHandlers[requestType] = handler;
-		this.sendRequestResponse(requestType);
-		return this;
-	}
-	open() {
-		if(this.isOpen) {
-			throw new Error('Port is already open.');
-		}
-		this.isOpen = true;
-		window.addEventListener('message', this.receiveMessage.bind(this), false);
-		this.debug('opened');
-		return this;
-	}
-	receiveMessage(e) {
 
-		if(!Port.validateEvent(this.targetOrigin, this.endpoint, e)) {
-			return;
-		}
+	options = options || {};
+	this._connectQueue = [];
+	this._debugEnabled = options.debug || false;
+	this._endpoint = endpoint;
+	this._eventHandlers = {};
+	this._isConnected = false;
+	this._isOpen = false;
+	this._onCloseCallbacks = [];
+	this._pendingRequests = {};
+	this._requestHandlers = {};
+	this._services = {};
+	this._targetOrigin = targetOrigin;
+	this._waitingRequests = [];
 
-		var messageType = e.data.key.substr(5,3);
-		var subType = e.data.key.substr(9);
-
-		this.debug(`received ${messageType}.${subType}`);
-
-		if(messageType === 'evt') {
-			this.receiveEvent(subType, e.data.payload);
-		} else if(messageType === 'req') {
-			this.receiveRequest(subType, e.data.payload);
-		} else if(messageType === 'res') {
-			this.receiveRequestResponse(subType, e.data.payload);
-		}
-
-	}
-	receiveEvent(eventType, payload) {
-		if(this.eventHandlers[eventType] === undefined) {
-			return;
-		}
-		this.eventHandlers[eventType].forEach(function(handler) {
-			handler.apply(handler, payload);
-		});
-	}
-	receiveRequest(requestType, payload) {
-		this.initHashArrAndPush(this.waitingRequests, requestType, payload);
-		this.sendRequestResponse(requestType);
-	}
-	receiveRequestResponse(requestType, payload) {
-
-		var requests = this.pendingRequests[requestType];
-		if(requests === undefined) {
-			return;
-		}
-
-		for(var i=0; i<requests.length; i++) {
-			var req = requests[i];
-			if(req.id !== payload.id) {
-				continue;
-			}
-
-			if (payload.hasOwnProperty('err')) {
-				const error = toError(payload.err);
-				req.reject(error);
-			} else {
-				req.resolve(payload.val);
-			}
-
-			requests.splice(i, 1);
-			return;
-		}
-
-	}
-	registerService(serviceType, version, service) {
-		if(this.isConnected) {
-			throw new Error('Register services before connecting');
-		}
-		if(!typeNameValidator.test(serviceType)) {
-			throw new Error(`Invalid service type "${serviceType}"`);
-		}
-		let methodNames = [];
-		for(let p in service) {
-			if(typeof(service[p]) === 'function') {
-				methodNames.push(p);
-				this.onRequest(`service:${serviceType}:${version}:${p}`, service[p]);
-			}
-		}
-		this.onRequest(`service:${serviceType}:${version}`, methodNames);
-		return this;
-	}
-	request(requestType) {
-		let args = [];
-		for(let i=1; i<arguments.length; i++) {
-			args.push(arguments[i]);
-		}
-		const me = this;
-		return new Promise((resolve, reject) => {
-			const id = `${me.id}_${++me.requestCounter}`;
-			me.initHashArrAndPush(
-					me.pendingRequests,
-					requestType,
-					{
-						id: id,
-						resolve,
-						reject
-					}
-				);
-			const finish = () => {
-				me.sendMessage(`req.${requestType}`,{id: id, args: args});
-			};
-			if(!me.isConnected) {
-				me.connectQueue.push(finish);
-			} else {
-				finish();
-			}
-		});
-	}
-	sendMessage(key, data) {
-		var message = {
-			key: `frau.${key}`,
-			payload: data
-		};
-		this.debug(`sending key: ${key}`);
-		this.endpoint.postMessage(message, this.targetOrigin);
-		return this;
-	}
-	sendEvent(eventType) {
-		let args = [];
-		for(let i=1; i<arguments.length; i++) {
-			args.push(arguments[i]);
-		}
-		if(!this.isConnected) {
-			const me = this;
-			this.connectQueue.push(() => {
-				me.sendMessage(`evt.${eventType}`, args);
-			});
-			return this;
-		}
-		return this.sendMessage(`evt.${eventType}`, args);
-	}
-	sendRequestResponse(requestType) {
-
-		var handler = this.requestHandlers[requestType];
-		var waiting = this.waitingRequests[requestType];
-		delete this.waitingRequests[requestType];
-
-		if(handler === undefined || waiting === undefined || waiting.length === 0) {
-			return;
-		}
-
-		var me = this;
-
-		waiting.forEach(function(w) {
-			Promise
-				.resolve()
-				.then(() => {
-					if (typeof(handler) === 'function') {
-						return handler.apply(handler, w.args);
-					}
-
-					// otherwise "handler" is a value / Promise
-					return handler;
-				})
-				.then((val) => {
-					me.sendMessage(`res.${requestType}`, { id: w.id, val: val });
-				})
-				.catch((e) => {
-					const err = fromError(e);
-
-					me.sendMessage(`res.${requestType}`, { id: w.id, err });
-				});
-		});
-
-	}
-	use(fn) {
-		fn(this);
-		return this;
-	}
-	static validateEvent(targetOrigin, endpoint, e) {
-		var isValid = (e.source === endpoint) &&
-		  (targetOrigin === '*' || !Port.isStringEmpty(targetOrigin) && !Port.isStringEmpty(e.origin) && targetOrigin.toUpperCase() === e.origin.toUpperCase()) &&
-			(e.data.key !== undefined) &&
-			(e.data.key !== null) &&
-			(e.data.key.indexOf('frau.') === 0);
-		return isValid;
-	}
-	static isStringEmpty(str) {
-		return (!str || 0 === str.length);
-	}
+	this._id = uuid();
+	this._requestCounter = 0;
 }
+
+Port.prototype.close = function close() {
+	if(!this._isOpen) {
+		throw new Error('Port cannot be closed, call open() first');
+	}
+	this._isOpen = false;
+	this._isConnected = false;
+	window.removeEventListener('message', this._receiveMessage);
+	this._onCloseCallbacks.forEach(function (cb) { cb(); });
+	this.debug('closed');
+};
+
+Port.prototype.connect = function connect() {
+	this._isConnected = true;
+	this.debug('connected');
+	this._connectQueue.forEach(function (func) { func(); });
+	this._connectQueue = [];
+	return this;
+};
+
+Port.prototype.debug = function debug(msg) {
+	if(this._debugEnabled) {
+		console.log(msg);
+	}
+};
+
+Port.prototype.getService = function getService(serviceType, version) {
+	if(!this._isConnected) {
+		throw new Error('Cannot getService() before connect() has completed');
+	}
+	var serviceVersionPrefix = 'service:' + serviceType + ':' + version;
+	var me = this;
+	function createProxyMethod(name) {
+		return function() {
+			var args = [serviceVersionPrefix + ':' + name];
+			for(var i=0; i<arguments.length; i++) {
+				args.push(arguments[i]);
+			}
+			return me.request.apply(me, args);
+		};
+	}
+	function createProxy(methodNames) {
+		var proxy = {};
+		methodNames.forEach(function(name) {
+			proxy[name] = createProxyMethod(name);
+		});
+		return proxy;
+	}
+	return me.request(serviceVersionPrefix).then(createProxy);
+};
+
+Port.prototype._initHashArrAndPush = function initHashArrAndPush(dic, key, obj) {
+	if(dic[key] === undefined ) {
+		dic[key] = [];
+	}
+	dic[key].push(obj);
+};
+
+Port.prototype.onClose = function onClose(cb) {
+	this._onCloseCallbacks.push(cb);
+};
+
+Port.prototype.onEvent = function onEvent(eventType, handler) {
+	this.debug('onEvent handler added for "' + eventType + '"');
+	if(this._isConnected) {
+		this.debug('You\'ve attached event handlers after connecting, you may have missed some events');
+	}
+	this._initHashArrAndPush(this._eventHandlers, eventType, handler);
+	return this;
+};
+
+Port.prototype.onRequest = function onRequest(requestType, handler) {
+	if(this._isConnected) {
+		throw new Error('Add request handlers before connecting');
+	}
+	if(this._requestHandlers[requestType] !== undefined) {
+		throw new Error('Duplicate onRequest handler for type "' + requestType + '"');
+	}
+	this.debug('onRequest handler added for "' + requestType + '"');
+	this._requestHandlers[requestType] = handler;
+	this._sendRequestResponse(requestType);
+	return this;
+};
+
+Port.prototype.open = function open() {
+	if(this._isOpen) {
+		throw new Error('Port is already open.');
+	}
+	this._isOpen = true;
+	window.addEventListener('message', this._receiveMessage.bind(this), false);
+	this.debug('opened');
+	return this;
+};
+
+Port.prototype._receiveMessage = function receiveMessage(e) {
+	if(!Port._validateEvent(this._targetOrigin, this._endpoint, e)) {
+		return;
+	}
+
+	var messageType = e.data.key.substr(5,3);
+	var subType = e.data.key.substr(9);
+
+	this.debug('received ' + messageType + '.' + subType);
+
+	if(messageType === 'evt') {
+		this._receiveEvent(subType, e.data.payload);
+	} else if(messageType === 'req') {
+		this._receiveRequest(subType, e.data.payload);
+	} else if(messageType === 'res') {
+		this._receiveRequestResponse(subType, e.data.payload);
+	}
+};
+
+Port.prototype._receiveEvent = function receiveEvent(eventType, payload) {
+	if(this._eventHandlers[eventType] === undefined) {
+		return;
+	}
+	this._eventHandlers[eventType].forEach(function(handler) {
+		handler.apply(handler, payload);
+	});
+};
+
+Port.prototype._receiveRequest = function receiveRequest(requestType, payload) {
+	this._initHashArrAndPush(this._waitingRequests, requestType, payload);
+	this._sendRequestResponse(requestType);
+};
+
+Port.prototype._receiveRequestResponse = function receiveRequestResponse(requestType, payload) {
+	var requests = this._pendingRequests[requestType];
+	if(requests === undefined) {
+		return;
+	}
+
+	for(var i=0; i<requests.length; i++) {
+		var req = requests[i];
+		if(req.id !== payload.id) {
+			continue;
+		}
+
+		if (payload.hasOwnProperty('err')) {
+			var error = toError(payload.err);
+			req.reject(error);
+		} else {
+			req.resolve(payload.val);
+		}
+
+		requests.splice(i, 1);
+		return;
+	}
+};
+
+Port.prototype.registerService = function registerService(serviceType, version, service) {
+	if(this._isConnected) {
+		throw new Error('Register services before connecting');
+	}
+	if(!typeNameValidator.test(serviceType)) {
+		throw new Error('Invalid service type "' + serviceType + '"');
+	}
+	var methodNames = [];
+	for(var p in service) {
+		if(typeof(service[p]) === 'function') {
+			methodNames.push(p);
+			this.onRequest('service:' + serviceType + ':' + version + ':' + p, service[p]);
+		}
+	}
+	this.onRequest('service:' + serviceType + ':' + version, methodNames);
+	return this;
+};
+
+Port.prototype.request = function request(requestType) {
+	var args = [];
+	for(var i=1; i<arguments.length; i++) {
+		args.push(arguments[i]);
+	}
+	var me = this;
+	return new Promise(function(resolve, reject) {
+		var counter = ++me._requestCounter;
+		var id = me._id + '_' + counter;
+		me._initHashArrAndPush(
+				me._pendingRequests,
+				requestType,
+				{
+					id: id,
+					resolve: resolve,
+					reject: reject
+				}
+			);
+		function finish() {
+			me.sendMessage('req.' + requestType,{id: id, args: args});
+		}
+		if(!me._isConnected) {
+			me._connectQueue.push(finish);
+		} else {
+			finish();
+		}
+	});
+};
+
+Port.prototype.sendMessage = function sendMessage(key, data) {
+	var message = {
+		key: 'frau.' + key,
+		payload: data
+	};
+	this.debug('sending key: ' + key);
+	this._endpoint.postMessage(message, this._targetOrigin);
+	return this;
+};
+
+Port.prototype.sendEvent = function sendEvent(eventType) {
+	var args = [];
+	for(var i=1; i<arguments.length; i++) {
+		args.push(arguments[i]);
+	}
+	if(!this._isConnected) {
+		var me = this;
+		this._connectQueue.push(function() {
+			me.sendMessage('evt.' + eventType, args);
+		});
+		return this;
+	}
+	return this.sendMessage('evt.' + eventType, args);
+};
+
+Port.prototype._sendRequestResponse = function sendRequestResponse(requestType) {
+
+	var handler = this._requestHandlers[requestType];
+	var waiting = this._waitingRequests[requestType];
+	delete this._waitingRequests[requestType];
+
+	if(handler === undefined || waiting === undefined || waiting.length === 0) {
+		return;
+	}
+
+	var me = this;
+
+	waiting.forEach(function(w) {
+		Promise
+			.resolve()
+			.then(function() {
+				if (typeof(handler) === 'function') {
+					return handler.apply(handler, w.args);
+				}
+
+				// otherwise "handler" is a value / Promise
+				return handler;
+			})
+			.then(function (val) {
+				me.sendMessage('res.' + requestType, { id: w.id, val: val });
+			})
+			.catch(function (e) {
+				var err = fromError(e);
+
+				me.sendMessage('res.' + requestType, { id: w.id, err: err });
+			});
+	});
+
+};
+
+Port.prototype.use = function use(fn) {
+	fn(this);
+	return this;
+};
+
+Port._isStringEmpty = function isStringEmpty(str) {
+	return (!str || 0 === str.length);
+};
+
+Port._validateEvent = function validateEvent(targetOrigin, endpoint, e) {
+	var isValid = (e.source === endpoint) &&
+	  (targetOrigin === '*' || !Port._isStringEmpty(targetOrigin) && !Port._isStringEmpty(e.origin) && targetOrigin.toUpperCase() === e.origin.toUpperCase()) &&
+		(e.data.key !== undefined) &&
+		(e.data.key !== null) &&
+		(e.data.key.indexOf('frau.') === 0);
+	return isValid;
+};
+
+module.exports = Port;

--- a/src/transform-error.js
+++ b/src/transform-error.js
@@ -1,18 +1,18 @@
-export const ERROR_OBJECT_SENTINEL = '_ifrau-error-object';
+var ERROR_OBJECT_SENTINEL = '_ifrau-error-object';
 
 function deErrorifyArray (input) {
-	const result = input.map(deErrorify);
+	var result = input.map(deErrorify);
 	return result;
 }
 
 function errorifyArray (input) {
-	const result = input.map(errorify);
+	var result = input.map(errorify);
 	return result;
 }
 
 function deErrorifyObject (input) {
-	const isError = input instanceof Error;
-	const result = isError ? { props: {} } : {};
+	var isError = input instanceof Error;
+	var result = isError ? { props: {} } : {};
 
 	if (isError) {
 		result.message = input.message;
@@ -21,31 +21,32 @@ function deErrorifyObject (input) {
 		result[ERROR_OBJECT_SENTINEL] = true;
 	}
 
-	const propTarget = isError ? result.props : result;
-	for (let key of Object.keys(input)) {
-		const prop = deErrorify(input[key]);
+	var propTarget = isError ? result.props : result;
+
+	Object.keys(input).forEach(function(key) {
+		var prop = deErrorify(input[key]);
 
 		propTarget[key] = prop;
-	}
+	});
 
 	return result;
 }
 
 function errorifyObject (input) {
-	const isError = input[ERROR_OBJECT_SENTINEL] === true;
+	var isError = input[ERROR_OBJECT_SENTINEL] === true;
 
-	const result = isError ? new Error(input.message) : {};
+	var result = isError ? new Error(input.message) : {};
 
 	if (isError) {
 		result.name = input.name;
 	}
 
-	const propSource = isError ? input.props : input;
-	for (let key of Object.keys(propSource)) {
-		const prop = errorify(propSource[key]);
+	var propSource = isError ? input.props : input;
+	Object.keys(propSource).forEach(function(key) {
+		var prop = errorify(propSource[key]);
 
 		result[key] = prop;
-	}
+	});
 
 	return result;
 }
@@ -79,5 +80,6 @@ function errorify (input) {
 	return input;
 }
 
-export { deErrorify as fromError };
-export { errorify as toError };
+module.exports.ERROR_OBJECT_SENTINEL = ERROR_OBJECT_SENTINEL;
+module.exports.fromError = deErrorify;
+module.exports.toError = errorify;

--- a/test/host.js
+++ b/test/host.js
@@ -46,13 +46,13 @@ describe('host', () => {
 		].forEach((src) => {
 			it(`should not throw for valid origin "${src}"`, () => {
 				var host = new Host(() => element, src);
-				expect(host.targetOrigin).to.equal(src);
+				expect(host._targetOrigin).to.equal(src);
 			});
 		});
 
 		it(`should resolve protocol-relative origin`, () => {
 			var host = new Host(() => element, '//foo.com');
-			expect(host.targetOrigin).to.equal('https://foo.com');
+			expect(host._targetOrigin).to.equal('https://foo.com');
 		});
 
 		it('should throw if parent missing', () => {
@@ -97,7 +97,7 @@ describe('host', () => {
 					expect(h).to.equal(host);
 					done();
 				});
-				host.receiveEvent('ready');
+				host._receiveEvent('ready');
 			});
 
 			it('should open the port', () => {
@@ -107,7 +107,7 @@ describe('host', () => {
 
 			it('should resolve promise when "ready" event is received', (done) => {
 				host.connect().then(() => done());
-				host.receiveEvent('ready');
+				host._receiveEvent('ready');
 			});
 
 			it(`should register for the "ready" event`, () => {

--- a/test/plugins/iframe-resizer.js
+++ b/test/plugins/iframe-resizer.js
@@ -2,7 +2,7 @@ var chai = require('chai'),
 	expect = chai.expect,
 	sinon = require('sinon');
 
-import { default as resizer } from '../../src/plugins/iframe-resizer';
+import { host as resizer } from '../../src/plugins/iframe-resizer';
 
 chai.should();
 chai.use(require('sinon-chai'));

--- a/test/plugins/sync-font.js
+++ b/test/plugins/sync-font.js
@@ -5,7 +5,7 @@ var chai = require('chai'),
 chai.should();
 chai.use(require('sinon-chai'));
 
-import { clientSyncFont, hostSyncFont } from '../../src/plugins/sync-font';
+import { client as clientSyncFont, host as hostSyncFont } from '../../src/plugins/sync-font';
 
 let MockClient = function() {};
 MockClient.prototype.request = function() {};

--- a/test/plugins/sync-lang.js
+++ b/test/plugins/sync-lang.js
@@ -5,7 +5,7 @@ var chai = require('chai'),
 chai.should();
 chai.use(require('sinon-chai'));
 
-import { clientSyncLang, hostSyncLang } from '../../src/plugins/sync-lang';
+import { client as clientSyncLang, host as hostSyncLang } from '../../src/plugins/sync-lang';
 
 let MockClient = function() {};
 MockClient.prototype.request = function() {};

--- a/test/plugins/sync-title.js
+++ b/test/plugins/sync-title.js
@@ -5,7 +5,7 @@ var chai = require('chai'),
 chai.should();
 chai.use(require('sinon-chai'));
 
-import { clientSyncTitle, hostSyncTitle } from '../../src/plugins/sync-title';
+import { client as clientSyncTitle, host as hostSyncTitle } from '../../src/plugins/sync-title';
 
 let mutationCallback = null;
 let MockMutationObserver = function(cb) {

--- a/test/port.js
+++ b/test/port.js
@@ -37,13 +37,13 @@ describe('port', () => {
 			port.open();
 			port.close();
 			global.window.removeEventListener
-				.should.have.been.calledWith('message', port.receiveMessage );
+				.should.have.been.calledWith('message', port._receiveMessage );
 		});
 
 		it('should disconnect port', () => {
 			port.open();
 			port.close();
-			expect(port.isConnected).to.be.false;
+			expect(port._isConnected).to.be.false;
 		});
 
 		it('should call onClose callbacks', () => {
@@ -157,13 +157,13 @@ describe('port', () => {
 
 		it('should create array entry if it does not exist', () => {
 			var hash = {};
-			port.initHashArrAndPush(hash, 'foo', 'bar');
+			port._initHashArrAndPush(hash, 'foo', 'bar');
 			expect(hash.foo).to.eql(['bar']);
 		});
 
 		it('should append to existing entry', () => {
 			var hash = { foo: ['bar'] };
-			port.initHashArrAndPush(hash, 'foo', 'hello');
+			port._initHashArrAndPush(hash, 'foo', 'hello');
 			expect(hash.foo).to.eql([ 'bar', 'hello']);
 		});
 
@@ -171,23 +171,23 @@ describe('port', () => {
 
 	describe('onEvent', () => {
 
-		var initHashArrAndPush, debug;
+		var _initHashArrAndPush, debug;
 
 		beforeEach(() => {
-			initHashArrAndPush = sinon.stub(port, 'initHashArrAndPush');
+			_initHashArrAndPush = sinon.stub(port, '_initHashArrAndPush');
 			debug = sinon.stub(port, 'debug');
 		});
 
 		afterEach(() => {
-			initHashArrAndPush.restore();
+			_initHashArrAndPush.restore();
 			debug.restore();
 		});
 
 		it('should add to eventHandlers', () => {
 			var handler = () => {};
 			port.onEvent('foo', handler);
-			initHashArrAndPush.should.have.been.calledWith(
-				port.eventHandlers, 'foo', handler
+			_initHashArrAndPush.should.have.been.calledWith(
+				port._eventHandlers, 'foo', handler
 			);
 		});
 
@@ -206,25 +206,25 @@ describe('port', () => {
 
 	describe('onRequest', () => {
 
-		var sendRequestResponse;
+		var _sendRequestResponse;
 
 		beforeEach(() => {
-			sendRequestResponse = sinon.stub(port, 'sendRequestResponse');
+			_sendRequestResponse = sinon.stub(port, '_sendRequestResponse');
 		});
 
 		afterEach(() => {
-			sendRequestResponse.restore();
+			_sendRequestResponse.restore();
 		});
 
-		it('should add to requestHandlers', () => {
+		it('should add to _requestHandlers', () => {
 			var handler = () => {};
 			port.onRequest('foo', handler);
-			expect(port.requestHandlers).to.eql({ foo: handler });
+			expect(port._requestHandlers).to.eql({ foo: handler });
 		});
 
 		it('should attempt to send response immediately', () => {
 			port.onRequest('foo', () => {});
-			sendRequestResponse.should.have.been.calledWith('foo');
+			_sendRequestResponse.should.have.been.calledWith('foo');
 		});
 
 		it('should throw if duplicate handler is defined', () => {
@@ -270,19 +270,19 @@ describe('port', () => {
 
 	});
 
-	describe('receiveEvent', () => {
+	describe('_receiveEvent', () => {
 
 		it('should not call handlers for different events', () => {
 			var handler = sinon.spy();
 			port.onEvent('foo', handler);
-			port.receiveEvent('bar');
+			port._receiveEvent('bar');
 			handler.should.not.have.been.called;
 		});
 
 		it('should pass payload as arguments to handler', () => {
 			var handler = sinon.spy();
 			port.onEvent('foo', handler);
-			port.receiveEvent('foo', ['bar', true, -2]);
+			port._receiveEvent('foo', ['bar', true, -2]);
 			handler.should.have.been.calledWith('bar', true, -2);
 		});
 
@@ -291,7 +291,7 @@ describe('port', () => {
 			var handler2 = sinon.spy();
 			port.onEvent('foo', handler1)
 				.onEvent('foo', handler2);
-			port.receiveEvent('foo', ['bar']);
+			port._receiveEvent('foo', ['bar']);
 			handler1.should.have.been.calledWith('bar');
 			handler2.should.have.been.calledWith('bar');
 		});
@@ -300,107 +300,107 @@ describe('port', () => {
 
 	describe('receiveMessage', () => {
 
-		var receiveEvent, receiveRequest, receiveRequestResponse;
+		var _receiveEvent, _receiveRequest, _receiveRequestResponse;
 
 		beforeEach(() => {
-			receiveEvent = sinon.stub(port, 'receiveEvent');
-			receiveRequest = sinon.stub(port, 'receiveRequest');
-			receiveRequestResponse = sinon.stub(port, 'receiveRequestResponse');
+			_receiveEvent = sinon.stub(port, '_receiveEvent');
+			_receiveRequest = sinon.stub(port, '_receiveRequest');
+			_receiveRequestResponse = sinon.stub(port, '_receiveRequestResponse');
 		});
 
 		afterEach(() => {
-			receiveEvent.restore();
-			receiveRequest.restore();
-			receiveRequestResponse.restore();
+			_receiveEvent.restore();
+			_receiveRequest.restore();
+			_receiveRequestResponse.restore();
 		});
 
 		it('should not handle invalid events', () => {
-			port.receiveMessage({ source: 'evil' });
-			receiveEvent.should.not.have.been.called;
-			receiveRequest.should.not.have.been.called;
-			receiveRequestResponse.should.not.have.been.called;
+			port._receiveMessage({ source: 'evil' });
+			_receiveEvent.should.not.have.been.called;
+			_receiveRequest.should.not.have.been.called;
+			_receiveRequestResponse.should.not.have.been.called;
 		});
 
 		it('should not handle unrecognized message types', () => {
-			port.receiveMessage({
+			port._receiveMessage({
 				source: endpoint,
 				origin: targetOrigin,
 				data: { key: 'frau.foo.bar' }
 			});
-			receiveEvent.should.not.have.been.called;
-			receiveRequest.should.not.have.been.called;
-			receiveRequestResponse.should.not.have.been.called;
+			_receiveEvent.should.not.have.been.called;
+			_receiveRequest.should.not.have.been.called;
+			_receiveRequestResponse.should.not.have.been.called;
 		});
 
-		it('should pass "evt" messages to "receiveEvent"', () => {
-			port.receiveMessage({
+		it('should pass "evt" messages to "_receiveEvent"', () => {
+			port._receiveMessage({
 				source: endpoint,
 				origin: targetOrigin,
 				data: { key: 'frau.evt.myEvent', payload: ['bar', false] }
 			});
-			receiveEvent.should.have.been.calledWith('myEvent', ['bar', false]);
+			_receiveEvent.should.have.been.calledWith('myEvent', ['bar', false]);
 		});
 
-		it('should pass "req" messages to "receiveRequest"', () => {
-			port.receiveMessage({
+		it('should pass "req" messages to "_receiveRequest"', () => {
+			port._receiveMessage({
 				source: endpoint,
 				origin: targetOrigin,
 				data: { key: 'frau.req.myRequest', payload: 'foo' }
 			});
-			receiveRequest.should.have.been.calledWith('myRequest', 'foo');
+			_receiveRequest.should.have.been.calledWith('myRequest', 'foo');
 		});
 
-		it('should pass "res" messages to "receiveRequestResponse"', () => {
-			port.receiveMessage({
+		it('should pass "res" messages to "_receiveRequestResponse"', () => {
+			port._receiveMessage({
 				source: endpoint,
 				origin: targetOrigin,
 				data: { key: 'frau.res.myResponse', payload: 23 }
 			});
-			receiveRequestResponse
+			_receiveRequestResponse
 				.should.have.been.calledWith('myResponse', 23);
 		});
 
 	});
 
-	describe('receiveRequest', () => {
+	describe('_receiveRequest', () => {
 
-		var sendRequestResponse, initHashArrAndPush;
+		var _sendRequestResponse, _initHashArrAndPush;
 
 		beforeEach(() => {
-			sendRequestResponse = sinon.stub(port, 'sendRequestResponse');
-			initHashArrAndPush = sinon.stub(port, 'initHashArrAndPush');
+			_sendRequestResponse = sinon.stub(port, '_sendRequestResponse');
+			_initHashArrAndPush = sinon.stub(port, '_initHashArrAndPush');
 		});
 
 		afterEach(() => {
-			sendRequestResponse.restore();
-			initHashArrAndPush.restore();
+			_sendRequestResponse.restore();
+			_initHashArrAndPush.restore();
 		});
 
-		it('should queue request in "waitingRequests"', () => {
-			port.receiveRequest('foo', { id: 'rId', args: ['bar', false, -1] });
-			initHashArrAndPush.should.have.been.calledWith(
-				port.waitingRequests,
+		it('should queue request in "_waitingRequests"', () => {
+			port._receiveRequest('foo', { id: 'rId', args: ['bar', false, -1] });
+			_initHashArrAndPush.should.have.been.calledWith(
+				port._waitingRequests,
 				'foo',
 				{ id: 'rId', args: ['bar', false, -1] }
 			);
 		});
 
 		it('should attempt to send response', () => {
-			port.receiveRequest('foo', { id: 'rId', args: [] });
-			sendRequestResponse.should.have.been.calledWith('foo');
+			port._receiveRequest('foo', { id: 'rId', args: [] });
+			_sendRequestResponse.should.have.been.calledWith('foo');
 		});
 
 	});
 
-	describe('receiveRequestResponse', () => {
+	describe('_receiveRequestResponse', () => {
 
 		it('should ignore responses which aren\'t pending', (done) => {
 			var req = {
 				resolve: sinon.spy(),
 				reject: sinon.spy()
 			};
-			port.pendingRequests.foo = [req];
-			port.receiveRequestResponse('bar', {id: port.requestId});
+			port._pendingRequests.foo = [req];
+			port._receiveRequestResponse('bar', {id: port.requestId});
 			setTimeout(() => {
 				req.resolve.should.not.have.been.called;
 				req.reject.should.not.have.been.called;
@@ -419,8 +419,8 @@ describe('port', () => {
 				resolve: sinon.spy(),
 				reject: sinon.spy()
 			};
-			port.pendingRequests.foo = [req1, req2];
-			port.receiveRequestResponse('foo', {id: 2});
+			port._pendingRequests.foo = [req1, req2];
+			port._receiveRequestResponse('foo', {id: 2});
 			setTimeout(() => {
 				req1.resolve.should.not.have.been.called;
 				req1.reject.should.not.have.been.called;
@@ -443,12 +443,12 @@ describe('port', () => {
 					reject: sinon.spy()
 				};
 
-			port.pendingRequests.foo = [errored, succeeded];
+			port._pendingRequests.foo = [errored, succeeded];
 
 			const err = fromError(new Error('bad things'));
 
-			port.receiveRequestResponse('foo', { id: errored.id, err });
-			port.receiveRequestResponse('foo', { id: succeeded.id });
+			port._receiveRequestResponse('foo', { id: errored.id, err });
+			port._receiveRequestResponse('foo', { id: succeeded.id });
 
 			setTimeout(() => {
 				errored.resolve.should.not.have.been.called;
@@ -536,22 +536,22 @@ describe('port', () => {
 
 	describe('request', () => {
 
-		var sendMessage, initHashArrAndPush;
+		var sendMessage, _initHashArrAndPush;
 
 		beforeEach(() => {
 			sendMessage = sinon.stub(port, 'sendMessage');
-			initHashArrAndPush = sinon.stub(port, 'initHashArrAndPush');
+			_initHashArrAndPush = sinon.stub(port, '_initHashArrAndPush');
 		});
 
 		afterEach(() => {
 			sendMessage.restore();
-			initHashArrAndPush.restore();
+			_initHashArrAndPush.restore();
 		});
 
 		it('should queue if not connected', () => {
 			port.request('foo');
 			sendMessage.should.not.have.been.called;
-			expect(port.connectQueue.length).to.equal(1);
+			expect(port._connectQueue.length).to.equal(1);
 		});
 
 		it('should send queued messages after connect', () => {
@@ -566,10 +566,10 @@ describe('port', () => {
 			expect(promise.then).to.be.defined;
 		});
 
-		it('should add to "pendingRequests"', () => {
+		it('should add to "_pendingRequests"', () => {
 			port.connect().request('foo');
-			initHashArrAndPush.should.have.been.calledWith(
-				port.pendingRequests,
+			_initHashArrAndPush.should.have.been.calledWith(
+				port._pendingRequests,
 				'foo'
 			);
 		});
@@ -578,7 +578,7 @@ describe('port', () => {
 			port.connect().request('foo');
 			sendMessage.should.have.been.calledWith(
 				'req.foo',
-				{ id: `${port.id}_1`, args: [] }
+				{ id: `${port._id}_1`, args: [] }
 			);
 		});
 
@@ -586,7 +586,7 @@ describe('port', () => {
 			port.connect().request('foo', 'bar', true, -3);
 			sendMessage.should.have.been.calledWith(
 				'req.foo',
-				{ id: `${port.id}_1`, args: ['bar', true, -3] }
+				{ id: `${port._id}_1`, args: ['bar', true, -3] }
 			);
 		});
 
@@ -594,8 +594,8 @@ describe('port', () => {
 			port.connect();
 			port.request('foo');
 			port.request('bar');
-			sendMessage.should.have.been.calledWith('req.foo', { id: `${port.id}_1`, args: [] } );
-			sendMessage.should.have.been.calledWith('req.bar', { id: `${port.id}_2`, args: [] } );
+			sendMessage.should.have.been.calledWith('req.foo', { id: `${port._id}_1`, args: [] } );
+			sendMessage.should.have.been.calledWith('req.bar', { id: `${port._id}_2`, args: [] } );
 		});
 
 	});
@@ -632,7 +632,7 @@ describe('port', () => {
 		it('should queue if not connected', () => {
 			port.sendEvent('foo', 'bar');
 			sendMessage.should.not.have.been.called;
-			expect(port.connectQueue.length).to.equal(1);
+			expect(port._connectQueue.length).to.equal(1);
 		});
 
 		it('should send queued messages after connect', () => {
@@ -657,7 +657,7 @@ describe('port', () => {
 
 	});
 
-	describe('sendRequestResponse', () => {
+	describe('_sendRequestResponse', () => {
 
 		var sendMessage;
 
@@ -680,9 +680,9 @@ describe('port', () => {
 			}), expect: 49}
 		].forEach((test) => {
 			it(`should handle ${test.name}-based responses`, (done) => {
-				port.requestHandlers.bar = test.val;
-				port.waitingRequests.bar = [{id: 1, args:[]}];
-				port.sendRequestResponse('bar');
+				port._requestHandlers.bar = test.val;
+				port._waitingRequests.bar = [{id: 1, args:[]}];
+				port._sendRequestResponse('bar');
 				setTimeout(() => {
 					sendMessage.should.have.been.calledWith(
 						'res.bar',
@@ -695,9 +695,9 @@ describe('port', () => {
 
 		it('should pass arguments to handler', (done) => {
 			var handler = sinon.spy();
-			port.requestHandlers.bar = handler;
-			port.waitingRequests.bar = [{id: 1, args:['p1', 'p2', true]}];
-			port.sendRequestResponse('bar');
+			port._requestHandlers.bar = handler;
+			port._waitingRequests.bar = [{id: 1, args:['p1', 'p2', true]}];
+			port._sendRequestResponse('bar');
 			setTimeout(() => {
 				handler.should.have.been.calledWith('p1', 'p2', true);
 				done();
@@ -706,12 +706,12 @@ describe('port', () => {
 
 		it('should pass different arguments to handler', (done) => {
 			var handler = sinon.spy();
-			port.requestHandlers.bar = handler;
-			port.waitingRequests.bar = [
+			port._requestHandlers.bar = handler;
+			port._waitingRequests.bar = [
 				{id: 1, args:['p1', 'p2', true]},
 				{id: 2, args:['p3', 'p4', false]}
 			];
-			port.sendRequestResponse('bar');
+			port._sendRequestResponse('bar');
 			setTimeout(() => {
 				handler.should.have.been.calledWith('p1', 'p2', true);
 				handler.should.have.been.calledWith('p3', 'p4', false);
@@ -720,9 +720,9 @@ describe('port', () => {
 		});
 
 		it('should send handler value to each waiting request', (done) => {
-			port.requestHandlers.bar = 'hello';
-			port.waitingRequests.bar = [{id: 1, args:[]}, {id: 2, args:[]}];
-			port.sendRequestResponse('bar');
+			port._requestHandlers.bar = 'hello';
+			port._waitingRequests.bar = [{id: 1, args:[]}, {id: 2, args:[]}];
+			port._sendRequestResponse('bar');
 			setTimeout(() => {
 				sendMessage.should.have.been.calledWith(
 					'res.bar',
@@ -737,8 +737,8 @@ describe('port', () => {
 		});
 
 		it('should not send a message if there is not handler', (done) => {
-			port.waitingRequests.bar = [{id: 1, args: []}];
-			port.sendRequestResponse('bar');
+			port._waitingRequests.bar = [{id: 1, args: []}];
+			port._sendRequestResponse('bar');
 			setTimeout(() => {
 				sendMessage.should.not.have.been.called;
 				done();
@@ -747,8 +747,8 @@ describe('port', () => {
 
 		it('should not call handler or send a message if no waiting requests', (done) => {
 			var handler = sinon.spy();
-			port.requestHandlers.bar = handler;
-			port.sendRequestResponse('bar');
+			port._requestHandlers.bar = handler;
+			port._sendRequestResponse('bar');
 			setTimeout(() => {
 				handler.should.not.have.been.called;
 				sendMessage.should.not.have.been.called;
@@ -763,10 +763,10 @@ describe('port', () => {
 			}
 
 			const reqType = 'bar';
-			port.requestHandlers[reqType] = handler;
-			port.waitingRequests[reqType] = [{ id: 1, args: [] }];
+			port._requestHandlers[reqType] = handler;
+			port._waitingRequests[reqType] = [{ id: 1, args: [] }];
 
-			port.sendRequestResponse(reqType);
+			port._sendRequestResponse(reqType);
 
 			setTimeout(() => {
 				sendMessage.should.have.been.calledWith('res.bar', {
@@ -784,10 +784,10 @@ describe('port', () => {
 			}
 
 			const reqType = 'bar';
-			port.requestHandlers[reqType] = handler;
-			port.waitingRequests[reqType] = [{ id: 1, args: [] }];
+			port._requestHandlers[reqType] = handler;
+			port._waitingRequests[reqType] = [{ id: 1, args: [] }];
 
-			port.sendRequestResponse(reqType);
+			port._sendRequestResponse(reqType);
 
 			setTimeout(() => {
 				sendMessage.should.have.been.calledWith('res.bar', {
@@ -831,7 +831,7 @@ describe('port', () => {
 			{endpoint: 'a', source: 'a', targetOrigin: '', origin: '', key: 'frau.valid', expect: false }
 		].forEach((item, index) => {
 			it(`should validate origin "${index}" to "${item.expect}"`, () => {
-				var isValid = Port.validateEvent(
+				var isValid = Port._validateEvent(
 					item.targetOrigin,
 					item.endpoint,
 					{ source: item.source, origin: item.origin, data: { key: item.key } }


### PR DESCRIPTION
```
omsmith osmith-ubuntu-t1700 | Fri Oct 23 at 11:24:41 | git master
/home/omsmith/dev/ifrau ~ git checkout master ^C
omsmith osmith-ubuntu-t1700 | Fri Oct 23 at 11:24:48 | git master
/home/omsmith/dev/ifrau ~ npm run browserify && ls -al dist

> ifrau@0.10.1 prebrowserify /home/omsmith/dev/ifrau
> rimraf dist && mkdir dist && npm run transpile


> ifrau@0.10.1 pretranspile /home/omsmith/dev/ifrau
> rimraf lib


> ifrau@0.10.1 transpile /home/omsmith/dev/ifrau
> babel src --optional runtime --out-dir lib

src/client.js -> lib/client.js
src/host.js -> lib/host.js
src/index.js -> lib/index.js
src/plugins/iframe-resizer.js -> lib/plugins/iframe-resizer.js
src/plugins/sync-font.js -> lib/plugins/sync-font.js
src/plugins/sync-lang.js -> lib/plugins/sync-lang.js
src/plugins/sync-title.js -> lib/plugins/sync-title.js
src/port.js -> lib/port.js
src/transform-error.js -> lib/transform-error.js

> ifrau@0.10.1 browserify /home/omsmith/dev/ifrau
> browserify -g uglifyify -s ifrau ./lib/index.js > ./dist/ifrau.js

total 88
drwxrwxr-x 2 omsmith omsmith  4096 Oct 23 11:24 .
drwxrwxr-x 9 omsmith omsmith  4096 Oct 23 11:24 ..
-rw-rw-r-- 1 omsmith omsmith 69726 Oct 23 11:24 ifrau.js
omsmith osmith-ubuntu-t1700 | Fri Oct 23 at 11:24:56 | git master
/home/omsmith/dev/ifrau ~ git checkout es5 
Switched to branch 'es5'
omsmith osmith-ubuntu-t1700 | Fri Oct 23 at 11:25:04 | git es5
/home/omsmith/dev/ifrau ~ npm run browserify && ls -al dist

> ifrau@0.10.1 prebrowserify /home/omsmith/dev/ifrau
> rimraf dist && mkdir dist


> ifrau@0.10.1 browserify /home/omsmith/dev/ifrau
> browserify -g uglifyify -s ifrau ./src/index.js > ./dist/ifrau.js

total 60
drwxrwxr-x 2 omsmith omsmith  4096 Oct 23 11:25 .
drwxrwxr-x 9 omsmith omsmith  4096 Oct 23 11:25 ..
-rw-rw-r-- 1 omsmith omsmith 43474 Oct 23 11:25 ifrau.js
```