### PR TITLE
refact(deploy) deploy seperate host/client bundles to the CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ npm install ifrau
 Or include it in your application as UMD/CommonJs from the Brightspace CDN:
 
 ```html
+<!-- probably what you're looking for -->
+<script src="https://s.brightspace.com/lib/ifrau/{version}/ifrau/client.js"></script>
+
+<!-- actually hosting a FRA on your page? grab the host -->
+<script src="https://s.brightspace.com/lib/ifrau/{version}/ifrau/host.js"></script>
+
+<!-- the old bundle is still available too -->
 <script src="https://s.brightspace.com/lib/ifrau/{version}/ifrau.js"></script>
 ```
 
@@ -32,12 +39,7 @@ It will build an `IFRAME` element, point it at the FRA endpoint, and wait for th
 To create a Host:
 
 ```javascript
-var Host = require('ifrau').Host;
-
-/*
- * We reccomend you use the following import if not pulling from the CDN
- * var Host = require('ifrau/host');
- */
+var Host = require('ifrau/host');
 
 function parentProvider() {
     return document.getElementById('myParentId');
@@ -65,12 +67,7 @@ Parameters:
 Creating a Client is even simpler:
 
 ```javascript
-var Client = require('ifrau').Client;
-
-/*
- * We reccomend you use the following import if not pulling from the CDN
- * var Client = require('ifrau/client');
- */
+var Client = require('ifrau/client');
 
 var client = new Client(options);
 client

--- a/package.json
+++ b/package.json
@@ -4,8 +4,11 @@
   "description": "Free-range app utility for IFRAME-based FRAs",
   "main": "src/index.js",
   "scripts": {
-    "prebrowserify": "rimraf dist && mkdir dist",
-    "browserify": "browserify -g uglifyify -s ifrau ./src/index.js > ./dist/ifrau.js",
+    "prebrowserify": "rimraf dist && mkdir -p dist/ifrau",
+    "browserify": "npm run browserify:full && npm run browserify:client && npm run browserify:host",
+    "browserify:client": "browserify -g uglifyify -s ifrau/client ./client.js > ./dist/ifrau/client.js",
+    "browserify:host": "browserify -g uglifyify -s ifrau/host ./host.js > ./dist/ifrau/host.js",
+    "browserify:full": "browserify -g uglifyify -s ifrau ./src/index.js > ./dist/ifrau.js",
     "lint": "eslint .",
     "prepublish:cdn": "npm run browserify",
     "publish:cdn": "frau-publisher | peanut-gallery",
@@ -15,7 +18,7 @@
   },
   "config": {
     "frauPublisher": {
-      "files": "./dist/ifrau.js",
+      "files": "./dist/**/*.js",
       "moduleType": "lib",
       "targetDirectory": "ifrau",
       "creds": {


### PR DESCRIPTION
First step on the path to world domination.

There's obviously `Port` overlap between host/client, but I wasn't too worried, just in terms of odds of both being loaded on the same page. Making a "common" bundle could be a next go for taking advantage of that level of caching, would require extra work for the consumers though.

@dlockhart @dbatiste 