### PR TITLE
Change heightCalculationMethod

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ifrau",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Free-range app utility for IFRAME-based FRAs",
   "main": "src/index.js",
   "scripts": {

--- a/src/plugins/iframe-resizer/host.js
+++ b/src/plugins/iframe-resizer/host.js
@@ -11,7 +11,8 @@ module.exports = function resizer(host) {
 		initialized = true;
 		iframeResizer(
 			{
-				log: host.debugEnabled
+				log: host.debugEnabled,
+				heightCalculationMethod: 'max'
 			},
 			host.iframe
 		);


### PR DESCRIPTION
* Use the 'max' [heightCalculationMethod](https://www.npmjs.com/package/iframe-resizer#heightcalculationmethod).
* Help ensure elements do not get cut off due to css stylings
* Members of D2L can reproduce the problem by building [this project](https://git.dev.d2l/users/mtjandrawidjaja/repos/minimalfra/browse)

Below is a sample picture of a paragraph being cut off when given the styling:
```
 p {
    margin: 1.5rem 0;
}
```
![cutoff](https://cloud.githubusercontent.com/assets/1176292/16623356/9bd1dfee-436b-11e6-938f-f8667bbdb555.PNG)
