### PR TITLE
Moving height to the style of the iframe, not the attribute

### DIFF
--- a/src/host.js
+++ b/src/host.js
@@ -66,7 +66,7 @@ Host._createIFrame = function createIFrame(src, frameId, height, allowFullScreen
 	var iframe = document.createElement('iframe');
 	iframe.width = '100%';
 	if (height || height === 0) {
-		iframe.height = height;
+		iframe.style.height = height;
 	}
 	iframe.style.border = 'none';
 	iframe.style.overflow = 'hidden';


### PR DESCRIPTION
This is a fix so that the height is applied to the style of the iframe, not its attribute. Previously it was an issue to apply any heights that had a length of rem, em, vh, etc. This fix will allow these heights to be input to the host. 