### PR TITLE
deps: update uuid and only pull in uuidv4

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "iframe-resizer": "^3.5.0",
     "inherits": "^2.0.1",
     "lie": "^3.0.2",
-    "uuid": "^2.0.1"
+    "uuid": "^3.1.0"
   },
   "devDependencies": {
     "browserify": "^13.0.0",

--- a/src/port/base.js
+++ b/src/port/base.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var uuid = require('uuid');
+var uuid = require('uuid/v4');
 
 var Promise = require('../promise-or-lie');
 


### PR DESCRIPTION
Updates uuid library to a version which includes the split out uuid type implementions. Reference uuid/v4 directly.

Shaves about 1KB pre-gzip in each of the bundles.