### PR TITLE
intl sync plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Parameters:
  * `debug`: whether to enable console debugging, `false` by default
  * `resizeFrame`: whether the `IFRAME` should automatically resize to fit its content, `true` by default
  * `syncFont`: whether to allow client to automatically sync its font size with the host, `false` by default
- * `syncLang`: whether to allow client to automatically sync its language with the host, `false` by default
+ * `syncLang`: whether to allow client to automatically sync its language and internationalization settings with the host, `false` by default
  * `syncPageTitle`: whether the page title (in the `<head>` element) should be kept in sync automatically with the title of the FRA, `false` by default
  * `height`: sets the iframe to a certain height, also disables automatic resizing
  * `id`: sets the id of the iframe

--- a/src/client.js
+++ b/src/client.js
@@ -7,6 +7,7 @@ var Promise = require('./promise-or-lie');
 var Port = require('./port'),
 	resizer = require('./plugins/iframe-resizer/client'),
 	syncLang = require('./plugins/sync-lang/client'),
+	syncIntl = require('./plugins/sync-intl/client'),
 	syncTitle = require('./plugins/sync-title/client'),
 	syncFont = require('./plugins/sync-font/client'),
 	userActivityEvents = require('./plugins/user-activity-events/client');
@@ -22,6 +23,7 @@ function Client(options) {
 
 	if (options.syncLang !== false) {
 		this.use(syncLang);
+		this.use(syncIntl);
 	}
 	if (options.syncTitle !== false) {
 		this.use(syncTitle);

--- a/src/host.js
+++ b/src/host.js
@@ -8,6 +8,7 @@ var Port = require('./port'),
 	resizer = require('./plugins/iframe-resizer/host'),
 	syncFont = require('./plugins/sync-font/host'),
 	syncLang = require('./plugins/sync-lang/host'),
+	syncIntl = require('./plugins/sync-intl/host'),
 	syncTitle = require('./plugins/sync-title/host');
 
 var originRe = /^(http:\/\/|https:\/\/)[^/]+/i;
@@ -38,6 +39,7 @@ function Host(elementProvider, src, options) {
 
 	if (options.syncLang) {
 		this.use(syncLang);
+		this.use(syncIntl);
 	}
 	this.use(syncTitle({page: options.syncPageTitle ? true : false}));
 

--- a/src/plugins/sync-intl/client.js
+++ b/src/plugins/sync-intl/client.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = function clientSyncIntl(client) {
+	return client.request('intl').then(function(intl) {
+		var htmlElems = document.getElementsByTagName('html');
+		if (htmlElems.length === 1) {
+			htmlElems[0].setAttribute(
+				'data-intl-overrides',
+				JSON.stringify(intl)
+			);
+		}
+	});
+};

--- a/src/plugins/sync-intl/host.js
+++ b/src/plugins/sync-intl/host.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = function hostSyncIntl(host) {
+	host.onRequest('intl', function() {
+		var htmlElems = document.getElementsByTagName('html');
+		if (htmlElems.length === 1 && htmlElems[0].hasAttribute('data-intl-overrides')) {
+			try {
+				return JSON.parse(
+					htmlElems[0].getAttribute('data-intl-overrides')
+				);
+			} catch (e) {}
+		}
+		return {};
+	});
+};

--- a/test/plugins/sync-intl.js
+++ b/test/plugins/sync-intl.js
@@ -1,0 +1,159 @@
+'use strict';
+
+const
+	expect = require('chai').expect,
+	sinon = require('sinon');
+
+require('chai')
+	.use(require('sinon-chai'))
+	.should();
+
+const
+	clientSyncIntl = require('../../src/plugins/sync-intl/client'),
+	hostSyncIntl = require('../../src/plugins/sync-intl/host');
+
+const MockClient = function() {};
+MockClient.prototype.request = function() {};
+
+const MockHost = function() {};
+MockHost.prototype.onRequest = function() {};
+
+describe('sync-intl', () => {
+
+	let getElementsByTagName;
+
+	beforeEach(() => {
+		getElementsByTagName = sinon.stub();
+		global.document = {
+			getElementsByTagName: getElementsByTagName
+		};
+	});
+
+	describe('client', () => {
+
+		let client, request;
+
+		beforeEach(() => {
+			client = new MockClient();
+			request = sinon.stub(client, 'request');
+		});
+
+		it('should request for "intl"', () => {
+			getElementsByTagName
+				.withArgs('html')
+				.returns([]);
+			request
+				.withArgs('intl')
+				.returns(Promise.resolve({}));
+			clientSyncIntl(client);
+			request.should.have.been.calledWith('intl');
+		});
+
+		it('should apply intl JSON to HTML element', (done) => {
+
+			const intlData = {foo: 'bar', bar: 5};
+
+			const setAttribute = sinon.stub();
+			getElementsByTagName
+				.withArgs('html')
+				.returns([{
+					setAttribute: setAttribute
+				}]);
+
+			request
+				.withArgs('intl')
+				.returns(Promise.resolve(intlData));
+
+			clientSyncIntl(client).then(() => {
+				setAttribute.should.have.been.calledWith(
+					'data-intl-overrides',
+					JSON.stringify(intlData)
+				);
+				done();
+			});
+
+		});
+
+		it('should do nothing if HTML element is not present', (done) => {
+
+			getElementsByTagName
+				.withArgs('html')
+				.returns([]);
+
+			request
+				.withArgs('intl')
+				.returns(new Promise((resolve) => {
+					resolve(true);
+				}));
+
+			clientSyncIntl(client).then(done);
+
+		});
+
+	});
+
+	describe('host', () => {
+
+		var host, onRequest;
+
+		beforeEach(() => {
+			host = new MockHost();
+			onRequest = sinon.spy(host, 'onRequest');
+		});
+
+		it('should add request handler for "intl"', () => {
+			hostSyncIntl(host);
+			onRequest.should.have.been.calledWith('intl');
+		});
+
+		it('should return parsed value of "data-intl-overrides" attribute from HTML element', () => {
+
+			const intlData = {foo: 'bar', bar: 5};
+
+			const hasAttribute = sinon.stub();
+			hasAttribute
+				.withArgs('data-intl-overrides')
+				.returns(true);
+
+			const getAttribute = sinon.stub();
+			getAttribute
+				.withArgs('data-intl-overrides')
+				.returns(JSON.stringify(intlData));
+
+			getElementsByTagName
+				.withArgs('html')
+				.returns([{
+					getAttribute: getAttribute,
+					hasAttribute: hasAttribute
+				}]);
+
+			hostSyncIntl(host);
+
+			const value = onRequest.args[0][1]();
+			expect(value).to.eql(intlData);
+
+		});
+
+		it('should return empty object if "data-intl-overrides" attribute not present', () => {
+
+			const hasAttribute = sinon.stub();
+			hasAttribute
+				.withArgs('data-intl-overrides')
+				.returns(false);
+
+			getElementsByTagName
+				.withArgs('html')
+				.returns([{
+					hasAttribute: hasAttribute
+				}]);
+
+			hostSyncIntl(host);
+
+			const value = onRequest.args[0][1]();
+			expect(value).to.eql({});
+
+		});
+
+	});
+
+});


### PR DESCRIPTION
This will keep the `data-intl-overrides` attribute on the <html> element in sync between the host and client. This attribute was recently exposed as a better way to get at a user's overrides compared to grabbing them off some arbitrary `D2L.Globalization.Whatever` global JS variable.

The plan is for libraries like `d2l-localize-behavior` to be able to use the HTML attribute to get at overrides and timezones in addition to grabbing the user's language like they do today.