### PR TITLE
Fix library to work on IE11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ifrau",
-  "version": "0.21.2",
+  "version": "0.22.1",
   "description": "Free-range app utility for IFRAME-based FRAs",
   "main": "src/index.js",
   "scripts": {

--- a/src/promise-or-lie.js
+++ b/src/promise-or-lie.js
@@ -1,5 +1,5 @@
 'use strict';
 
-module.exports = typeof Promise === undefined
+module.exports = typeof Promise === 'undefined'
 	? require('lie')
 	: global.Promise;


### PR DESCRIPTION
Versions `0.21.1`, `0.21.2`, and `0.22.0` all break on IE11. This PR fixes that problem. Other browsers are unaffected.

Don't have permissions to merge, request, reviewers, or publish, so I'll need someone to do that for me.

I also have a branch [here](https://github.com/mpharoah-d2l/ifrau/tree/mpharoah/fix-ie11-backport-to-v21) for backporting this fix to `0.21.*` so that people using `^` in their FRA dependencies will get the fix automatically even if they are on version 0.21.X still. (Needs to be moves to a branch in the main Brightspace repo and published by someone with write privileges)