### PR TITLE
Undid changes made to change where dir is being set to avoid causes i…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ifrau",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "Free-range app utility for IFRAME-based FRAs",
   "main": "src/index.js",
   "scripts": {

--- a/src/plugins/sync-lang/client.js
+++ b/src/plugins/sync-lang/client.js
@@ -8,7 +8,7 @@ module.exports = function clientSyncLang(client) {
 			htmlElem.setAttribute('data-lang-default', lang.fallback);
 		}
 		if (lang.isRtl) {
-			document.dir = 'rtl';
+			document.body.dir = 'rtl';
 		}
 	});
 };

--- a/src/plugins/sync-lang/host.js
+++ b/src/plugins/sync-lang/host.js
@@ -3,7 +3,7 @@
 module.exports = function hostSyncLang(host) {
 	host.onRequest('lang', function() {
 		var htmlElem = document.getElementsByTagName('html')[0];
-		var isRtl = (document.dir.toLowerCase() === 'rtl');
+		var isRtl = (document.body.dir.toLowerCase() === 'rtl');
 		return {
 			isRtl: isRtl,
 			lang: htmlElem.getAttribute('lang'),

--- a/test/plugins/sync-lang.js
+++ b/test/plugins/sync-lang.js
@@ -26,7 +26,7 @@ describe('sync-lang', () => {
 		setAttribute = sinon.stub();
 		getAttribute = sinon.stub();
 		global.document = {
-			dir: '',
+			body:{dir: ''},
 			getElementsByTagName: function() {
 				return [{
 					getAttribute: getAttribute,
@@ -75,12 +75,12 @@ describe('sync-lang', () => {
 			});
 		});
 
-		it('should set RTL direction on html', (done) => {
+		it('should set RTL direction on body', (done) => {
 			request.returns(new Promise((resolve) => {
 				resolve({isRtl: true});
 			}));
 			clientSyncLang(client).then(() => {
-				expect(document.dir).to.equal('rtl');
+				expect(document.body.dir).to.equal('rtl');
 				done();
 			});
 		});
@@ -119,15 +119,15 @@ describe('sync-lang', () => {
 			expect(value.fallback).to.equal('ef-GH');
 		});
 
-		it('should be RTL html direction is RTL', () => {
-			global.document.dir = 'RtL';
+		it('should be RTL body direction is RTL', () => {
+			global.document.body.dir = 'RtL';
 			hostSyncLang(host);
 			const value = onRequest.args[0][1]();
 			expect(value.isRtl).to.be.true;
 		});
 
-		it('should not be RTL html direction is not RTL', () => {
-			global.document.dir = 'abc';
+		it('should not be RTL body direction is not RTL', () => {
+			global.document.body.dir = 'abc';
 			hostSyncLang(host);
 			const value = onRequest.args[0][1]();
 			expect(value.isRtl).to.be.false;


### PR DESCRIPTION
…ssues for projects set to use newest minor version

I'm pretty sure my previous change will break things for anyone who publishes a new version of their project, and is using "ifrau": ^0.x.x. If nothing else, RTL will be messed up until I merge the backend changes.

I think I should publish a version 0.24.1 that restores things, and then publish a version 1.0.0, with the changes to where we set and grab the dir attribute value.