### PR TITLE
pulling the CSS variable values from HTML element

### DIFF
--- a/src/plugins/sync-css-variable/host.js
+++ b/src/plugins/sync-css-variable/host.js
@@ -2,12 +2,12 @@
 
 module.exports = function hostSyncCssVariable(host) {
 	host.onRequest('css-variable', function() {
-		var elem  = document.getElementById('d2l-branding-vars');
-		if (elem && elem.hasAttribute('data-css-vars')) {
-			var data = elem.getAttribute('data-css-vars');
+		var htmlElems = document.getElementsByTagName('html');
+		if (htmlElems.length === 1 && htmlElems[0].hasAttribute('data-css-vars')) {
 			try {
-				var cssVariables = JSON.parse(data);
-				return cssVariables;
+				return JSON.parse(
+					htmlElems[0].getAttribute('data-css-vars')
+				);
 			} catch (e) {}
 		}
 		return {};

--- a/test/plugins/sync-css-variable.js
+++ b/test/plugins/sync-css-variable.js
@@ -20,14 +20,11 @@ MockHost.prototype.onRequest = function() {};
 
 describe('css-variable', () => {
 	let getElementsByTagName;
-	let getElementById;
 
 	beforeEach(() => {
 		getElementsByTagName = sinon.stub();
-		getElementById = sinon.stub();
 		global.document = {
-			getElementsByTagName: getElementsByTagName,
-			getElementById: getElementById
+			getElementsByTagName: getElementsByTagName
 		};
 	});
 
@@ -109,17 +106,6 @@ describe('css-variable', () => {
 			onRequest.should.have.been.calledWith('css-variable');
 		});
 
-		it('should return empty object if "d2l-branding-vars" id not present', () => {
-			getElementById
-				.withArgs('d2l-branding-vars')
-				.returns(null);
-
-			hostSyncCssVariable(host);
-
-			const value = onRequest.args[0][1]();
-			expect(value).to.eql({});
-		});
-
 		it('should return parsed value of "data-css-vars" attribute from HTML element', () => {
 			const cssVariables = {
 				'branding-color': 'green'
@@ -135,12 +121,12 @@ describe('css-variable', () => {
 				.withArgs('data-css-vars')
 				.returns(JSON.stringify(cssVariables));
 
-			getElementById
-				.withArgs('d2l-branding-vars')
-				.returns({
+			getElementsByTagName
+				.withArgs('html')
+				.returns([{
 					hasAttribute: hasAttribute,
 					getAttribute: getAttribute
-				});
+				}]);
 
 			hostSyncCssVariable(host);
 
@@ -154,14 +140,23 @@ describe('css-variable', () => {
 				.withArgs('data-css-vars')
 				.returns(false);
 
-			getElementById
-				.withArgs('d2l-branding-vars')
-				.returns({
+			getElementsByTagName
+				.withArgs('html')
+				.returns([{
 					hasAttribute: hasAttribute
-				});
+				}]);
 
 			hostSyncCssVariable(host);
 
+			const value = onRequest.args[0][1]();
+			expect(value).to.eql({});
+		});
+
+		it('should return empty object if HTML element is not present', () => {
+			getElementsByTagName
+				.withArgs('html')
+				.returns([]);
+			hostSyncCssVariable(host);
 			const value = onRequest.args[0][1]();
 			expect(value).to.eql({});
 		});


### PR DESCRIPTION
A couple reasons for this change:

1. It's more consistent with how lang, intl and timezone synchronization happens (data attributes on the HTML element).
2. I'm going to be making changes to how `<custom-style>` gets written out in the monolith, and I don't want to have to expose an arbitrary dictionary of attributes that can be set (like `id="d2l-branding-vars"). Instead, I'm going to output this data on the HTML element directly via the data attribute.