### PR TITLE
Update font size cases from host

### DIFF
--- a/src/plugins/sync-font/client.js
+++ b/src/plugins/sync-font/client.js
@@ -5,13 +5,13 @@ module.exports = function clientSyncFont(client) {
 		var size = font.size;
 		if (!font.visualRedesign) {
 			switch (font.size) {
-				case '11px':
+				case '17.1px':
 					size = '18px';
 					break;
-				case '17px':
+				case '19px':
 					size = '22px';
 					break;
-				case '26px':
+				case '22.8px':
 					size = '24px';
 					break;
 				default:


### PR DESCRIPTION
Using `syncFont: true` does not work in Manager Dashboard because the sizes in this switch are never met. Perhaps these should be ranges instead?