### PR TITLE
Maboelsoudd2l/remove visual redesign

### DIFF
--- a/src/plugins/sync-font/client.js
+++ b/src/plugins/sync-font/client.js
@@ -2,23 +2,6 @@
 
 module.exports = function clientSyncFont(client) {
 	return client.request('font').then(function(font) {
-		var size = font.size;
-		if (!font.visualRedesign) {
-			switch (font.size) {
-				case '11px':
-					size = '18px';
-					break;
-				case '17px':
-					size = '22px';
-					break;
-				case '26px':
-					size = '24px';
-					break;
-				default:
-					size = '20px';
-					break;
-			}
-		}
-		document.documentElement.style.fontSize = size;
+		document.documentElement.style.fontSize = font.size;
 	});
 };

--- a/test/plugins/sync-font.js
+++ b/test/plugins/sync-font.js
@@ -57,8 +57,7 @@ describe('sync-font', () => {
 		beforeEach(() => {
 			response = {
 				family: 'foo',
-				size: '20px',
-				visualRedesign: false
+				size: '20px'
 			};
 			client = new MockClient();
 			request = sinon.stub(client, 'request').returns(
@@ -84,25 +83,7 @@ describe('sync-font', () => {
 			});
 		});
 
-		[
-			{source: '11px', expected: '18px'},
-			{source: '13px', expected: '20px'},
-			{source: '17px', expected: '22px'},
-			{source: '26px', expected: '24px'},
-			{source: '1px', expected: '20px'},
-			{source: 'foo', expected: '20px'}
-		].forEach((val) => {
-			it(`should convert ${val.source} to ${val.expected}`, (done) => {
-				response.size = val.source;
-				clientSyncFont(client).then(() => {
-					expect(document.documentElement.style.fontSize).to.equal(val.expected);
-					done();
-				});
-			});
-		});
-
-		it('should not convert font sizes if flag is on', (done) => {
-			response.visualRedesign = true;
+		it('should have the same font size', (done) => {
 			response.size = '13px';
 			clientSyncFont(client).then(() => {
 				expect(document.documentElement.style.fontSize).to.equal('13px');


### PR DESCRIPTION
since Daylight is always ON now, this is no longer needed. And it breaks syncFont functionality anyways.