### PR TITLE
Extend ifrau to pass "data-oslo" attribute

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+coverage
+dist

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,0 @@
-.gitignore
-dist/**
-coverage/**

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,3 @@
 .gitignore
+dist/**
+coverage/**

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Parameters:
  * `debug`: whether to enable console debugging, `false` by default
  * `resizeFrame`: whether the `IFRAME` should automatically resize to fit its content, `true` by default
  * `syncFont`: whether to allow client to automatically sync its font size with the host, `false` by default
- * `syncLang`: whether to allow client to automatically sync its language, timezone and internationalization settings with the host, `false` by default
+ * `syncLang`: whether to allow client to automatically sync its language, timezone, internationalization, and OSLO settings with the host, `false` by default
  * `syncPageTitle`: whether the page title (in the `<head>` element) should be kept in sync automatically with the title of the FRA, `false` by default
  * `syncCssVariable`: whether css variables (in the `<head>` element) should be kept in sync automatically with the css variables of the FRA, `false` by default
  * `height`: sets the iframe to a certain height, also disables automatic resizing

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ifrau",
-  "version": "0.32.1",
+  "version": "0.33.0",
   "description": "Free-range app utility for IFRAME-based FRAs",
   "main": "src/index.js",
   "scripts": {

--- a/src/host.js
+++ b/src/host.js
@@ -7,7 +7,8 @@ var Port = require('./port'),
 	syncIntl = require('./plugins/sync-intl/host'),
 	syncTimezone = require('./plugins/sync-timezone/host'),
 	syncTitle = require('./plugins/sync-title/host'),
-	syncCssVariable = require('./plugins/sync-css-variable/host');
+	syncCssVariable = require('./plugins/sync-css-variable/host'),
+	syncOslo = require('./plugins/sync-oslo/host');
 
 var originRe = /^(http:\/\/|https:\/\/)[^/]+/i;
 
@@ -39,6 +40,7 @@ function Host(elementProvider, src, options) {
 		this.use(syncLang);
 		this.use(syncIntl);
 		this.use(syncTimezone);
+		this.use(syncOslo);
 	}
 	this.use(syncTitle({ page: options.syncPageTitle ? true : false }));
 

--- a/src/plugins/sync-oslo/client.js
+++ b/src/plugins/sync-oslo/client.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = function clientSyncOslo(client) {
+	return client.request('oslo').then(function(oslo) {
+		var htmlElems = document.getElementsByTagName('html');
+		if (htmlElems.length === 1 && oslo) {
+			htmlElems[0].setAttribute(
+				'data-oslo',
+				JSON.stringify(oslo)
+			);
+		}
+	});
+};

--- a/src/plugins/sync-oslo/client.js
+++ b/src/plugins/sync-oslo/client.js
@@ -1,5 +1,3 @@
-'use strict';
-
 module.exports = function clientSyncOslo(client) {
 	return client.request('oslo').then(function(oslo) {
 		var htmlElems = document.getElementsByTagName('html');

--- a/src/plugins/sync-oslo/host.js
+++ b/src/plugins/sync-oslo/host.js
@@ -1,5 +1,3 @@
-'use strict';
-
 module.exports = function hostSyncOslo(host) {
 	host.onRequest('oslo', function() {
 		var htmlElems = document.getElementsByTagName('html');

--- a/src/plugins/sync-oslo/host.js
+++ b/src/plugins/sync-oslo/host.js
@@ -1,0 +1,19 @@
+'use strict';
+
+module.exports = function hostSyncOslo(host) {
+	host.onRequest('oslo', function() {
+		var htmlElems = document.getElementsByTagName('html');
+		if (htmlElems.length === 1 && htmlElems[0].hasAttribute('data-oslo')) {
+			try {
+				var osloData = JSON.parse(
+					htmlElems[0].getAttribute('data-oslo')
+				);
+				osloData.batch = new window.URL(osloData.batch, window.location.origin).href;
+				osloData.collection = new window.URL(osloData.collection, window.location.origin).href;
+
+				return osloData;
+			} catch (e) {}
+		}
+		return;
+	});
+};

--- a/test/host.js
+++ b/test/host.js
@@ -16,7 +16,15 @@ describe('host', () => {
 
 	beforeEach(() => {
 		global.window = {
-			location: { protocol: 'https:' }
+			location: { protocol: 'https:', origin: 'https://dummy' },
+			URL: class {
+				constructor(path, base) {
+					this._href = `${base}/${path}`;
+				}
+				get href() {
+					return this._href;
+				}
+			}
 		};
 		global.document = {
 			createElement: sinon.stub().returns({

--- a/test/plugins/sync-oslo.js
+++ b/test/plugins/sync-oslo.js
@@ -1,0 +1,172 @@
+'use strict';
+
+const
+	expect = require('chai').expect,
+	sinon = require('sinon');
+
+require('chai')
+	.use(require('sinon-chai'))
+	.should();
+
+const
+	clientSyncOslo = require('../../src/plugins/sync-oslo/client'),
+	hostSyncOslo = require('../../src/plugins/sync-oslo/host');
+
+const MockClient = function() {};
+MockClient.prototype.request = function() {};
+
+const MockHost = function() {};
+MockHost.prototype.onRequest = function() {};
+
+describe('sync-oslo', () => {
+	let getElementsByTagName;
+
+	beforeEach(() => {
+		getElementsByTagName = sinon.stub();
+		global.document = {
+			getElementsByTagName: getElementsByTagName
+		};
+		global.window = {
+			location: { protocol: 'https:', origin: 'https://dummy' },
+			URL: class {
+				constructor(path, base) {
+					this._href = `${base}/${path}`;
+				}
+				get href() {
+					return this._href;
+				}
+			}
+		};
+	});
+
+	describe('client', () => {
+		let client, request;
+
+		beforeEach(() => {
+			client = new MockClient();
+			request = sinon.stub(client, 'request');
+		});
+
+		it('should request for "oslo"', () => {
+			getElementsByTagName
+				.withArgs('html')
+				.returns([]);
+			request
+				.withArgs('oslo')
+				.returns(Promise.resolve({}));
+			clientSyncOslo(client);
+			request.should.have.been.calledWith('oslo');
+		});
+
+		it('should apply oslo JSON to HTML element', (done) => {
+
+			const osloData = {
+				batch: 'batch',
+				collection: 'collection',
+				version: 'version'
+			};
+
+			const setAttribute = sinon.stub();
+			getElementsByTagName
+				.withArgs('html')
+				.returns([{
+					setAttribute: setAttribute
+				}]);
+
+			request
+				.withArgs('oslo')
+				.returns(Promise.resolve(osloData));
+
+			clientSyncOslo(client).then(() => {
+				setAttribute.should.have.been.calledWith(
+					'data-oslo',
+					JSON.stringify(osloData)
+				);
+				done();
+			});
+		});
+
+		it('should do nothing if HTML element is not present', (done) => {
+
+			getElementsByTagName
+				.withArgs('html')
+				.returns([]);
+
+			request
+				.withArgs('oslo')
+				.returns(new Promise((resolve) => {
+					resolve(true);
+				}));
+
+			clientSyncOslo(client).then(done);
+		});
+	});
+
+	describe('host', () => {
+		var host, onRequest;
+
+		beforeEach(() => {
+			host = new MockHost();
+			onRequest = sinon.spy(host, 'onRequest');
+		});
+
+		it('should add request handler for "oslo"', () => {
+			hostSyncOslo(host);
+			onRequest.should.have.been.calledWith('oslo');
+		});
+
+		it('should return parsed value of "data-oslo" attribute from HTML element', () => {
+
+			const osloData = {
+				batch: 'batch',
+				collection: 'collection',
+				version: 'version'
+			};
+
+			const hasAttribute = sinon.stub();
+			hasAttribute
+				.withArgs('data-oslo')
+				.returns(true);
+
+			const getAttribute = sinon.stub();
+			getAttribute
+				.withArgs('data-oslo')
+				.returns(JSON.stringify(osloData));
+
+			getElementsByTagName
+				.withArgs('html')
+				.returns([{
+					getAttribute: getAttribute,
+					hasAttribute: hasAttribute
+				}]);
+
+			hostSyncOslo(host);
+
+			const value = onRequest.args[0][1]();
+			expect(value).to.eql({
+				batch: 'https://dummy/batch',
+				collection: 'https://dummy/collection',
+				version: 'version'
+			});
+		});
+
+		it('should return empty object if "data-oslo" attribute not present', () => {
+
+			const hasAttribute = sinon.stub();
+			hasAttribute
+				.withArgs('data-oslo')
+				.returns(false);
+
+			getElementsByTagName
+				.withArgs('html')
+				.returns([{
+					hasAttribute: hasAttribute
+				}]);
+
+			hostSyncOslo(host);
+
+			const value = onRequest.args[0][1]();
+			expect(value).to.be.undefined;
+		});
+	});
+});

--- a/test/plugins/sync-oslo.js
+++ b/test/plugins/sync-oslo.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const
 	expect = require('chai').expect,
 	sinon = require('sinon');


### PR DESCRIPTION
https://rally1.rallydev.com/#/29180338367ud/iterationstatus?detail=%2Fuserstory%2F435427801908

Converting the oslo paths to a full path, so it can be consumed correctly by `getLocalizeOverrideResources`  inside FRA. 