### PR TITLE
Apply dir="rtl" to the html element.

### DIFF
--- a/src/plugins/sync-lang/client.js
+++ b/src/plugins/sync-lang/client.js
@@ -6,6 +6,7 @@ module.exports = function clientSyncLang(client) {
 			htmlElem.setAttribute('data-lang-default', lang.fallback);
 		}
 		if (lang.isRtl) {
+			htmlElem.setAttribute('dir', 'rtl');
 			document.dir = 'rtl';
 		}
 	});

--- a/test/plugins/sync-lang.js
+++ b/test/plugins/sync-lang.js
@@ -78,6 +78,7 @@ describe('sync-lang', () => {
 				resolve({ isRtl: true });
 			}));
 			clientSyncLang(client).then(() => {
+				setAttribute.should.have.been.calledWith('dir', 'rtl');
 				expect(document.dir).to.equal('rtl');
 				done();
 			});


### PR DESCRIPTION
This PR updates `sync-lang.js` to also apply `dir="rtl"` to the `html` element the same way that the LMS does.  Our core components (and other components) rely on `dir="rtl"` on the `html` element.

This PR fixes https://github.com/BrightspaceUI/core/issues/1019.