### PR TITLE
fixing title sync so that page title in synced by default

### DIFF
--- a/src/plugins/sync-title/client.js
+++ b/src/plugins/sync-title/client.js
@@ -34,10 +34,10 @@ function installClientMutation(sync) {
 module.exports = function(syncPage) {
 	function clientSyncTitle(client) {
 		function sync(value) {
-			if (syncPage) {
-				client.sendEvent('title', value);
-			} else {
+			if (syncPage === false) {
 				client.sendEvent('title', value, true);
+			} else {
+				client.sendEvent('title', value, false);
 			}
 		}
 

--- a/test/plugins/sync-title.js
+++ b/test/plugins/sync-title.js
@@ -111,13 +111,19 @@ describe('sync-title', () => {
 			it('should sync after 100ms', () => {
 				clientSyncTitle(true)(client);
 				clock.tick(100);
-				sendEvent.should.have.been.calledWith('title', 'init title');
+				sendEvent.should.have.been.calledWith('title', 'init title', false);
 			});
 
 			it('should only sync iframe title after 100ms', () => {
 				clientSyncTitle(false)(client);
 				clock.tick(100);
 				sendEvent.should.have.been.calledWith('title', 'init title', true);
+			});
+
+			it('should sync page title if no value is provided', () => {
+				clientSyncTitle()(client);
+				clock.tick(100);
+				sendEvent.should.have.been.calledWith('title', 'init title', false);
 			});
 
 			it('should not sync if title remains the same', () => {
@@ -131,7 +137,7 @@ describe('sync-title', () => {
 				clock.tick(100);
 				global.document.title = 'new title';
 				clock.tick(100);
-				sendEvent.should.have.been.calledWith('title', 'new title');
+				sendEvent.should.have.been.calledWith('title', 'new title', false);
 			});
 
 			it('should only sync iframeTitle if title changes', () => {


### PR DESCRIPTION
This should resolve the issue you were seeing @quinnbudan.

It'll now pass `false` as the `iframeOnly` sync option to the host only if `false` was explicitly passed into the client for the `syncTitle` value. Previously, if no value was passed in (the default) it would have synced only the iframe title.