### PR TITLE
fix: Use frau-publisher with a hub role

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,12 +29,21 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.D2L_GITHUB_TOKEN }}
           NPM: true
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Assume role
+        if: steps.semantic-release.outputs.VERSION != ''
+        uses: Brightspace/third-party-actions@aws-actions/configure-aws-credentials
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
+          role-to-assume: "arn:aws:iam::771734770799:role/cdn-infrastructure-ifrau"
+          role-duration-seconds: 3600
+          aws-region: us-east-1
       - name: Publish to CDN
         if: steps.semantic-release.outputs.VERSION != ''
         run: |
             echo "Publishing to the CDN as version: ${{ steps.semantic-release.outputs.VERSION }}"
             npx frau-publisher --v="${{ steps.semantic-release.outputs.VERSION }}" --f="./dist/**/*.js" --m="lib" --t="ifrau"
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
+          # cred variables set in the "Assume role" step
+          AWS_DEFAULT_REGION: us-east-1


### PR DESCRIPTION
I think this should work, but I'm going to have to see when I try releasing.  I'm using https://github.com/Brightspace/lms/blob/master/.github/workflows/insights-cdn.yml as an example, which uses the aws cli, not the sdk.  But either _should_ work...