### PR TITLE
US130990 - Marshal all html element data attributes into FRA iframe

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -38,7 +38,7 @@ function Client(options) {
 	}
 	this.use(userActivityEvents);
 	this.use(syncTitle(options.syncTitle));
-	this.use(syncDataAttrs);
+	this.use(syncDataAttrs.default);
 }
 inherits(Client, SlimClient);
 

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -2,6 +2,7 @@ var inherits = require('inherits');
 
 var SlimClient = require('./slim'),
 	resizer = require('../plugins/iframe-resizer/client'),
+	syncDataAttrs = require('../plugins/sync-data-attrs/client'),
 	syncLang = require('../plugins/sync-lang/client'),
 	syncIntl = require('../plugins/sync-intl/client'),
 	syncTimezone = require('../plugins/sync-timezone/client'),
@@ -37,6 +38,7 @@ function Client(options) {
 	}
 	this.use(userActivityEvents);
 	this.use(syncTitle(options.syncTitle));
+	this.use(syncDataAttrs);
 }
 inherits(Client, SlimClient);
 

--- a/src/host.js
+++ b/src/host.js
@@ -2,6 +2,7 @@ var inherits = require('inherits');
 
 var Port = require('./port'),
 	resizer = require('./plugins/iframe-resizer/host'),
+	syncDataAttrs = require('./plugins/sync-data-attrs/host'),
 	syncFont = require('./plugins/sync-font/host'),
 	syncLang = require('./plugins/sync-lang/host'),
 	syncIntl = require('./plugins/sync-intl/host'),
@@ -54,6 +55,7 @@ function Host(elementProvider, src, options) {
 	if (options.syncCssVariable) {
 		this.use(syncCssVariable);
 	}
+	this.use(syncDataAttrs);
 }
 inherits(Host, Port);
 

--- a/src/plugins/sync-data-attrs/client.js
+++ b/src/plugins/sync-data-attrs/client.js
@@ -1,0 +1,18 @@
+var excludedAttrs = [
+	'intlOverrides',
+	'langDefault',
+	'oslo',
+	'timezone'
+];
+
+module.exports = function clientSyncDataAttrs(client) {
+	return client.request('attrs').then(function(dataAttrs) {
+		var htmlElems = document.getElementsByTagName('html');
+		if (htmlElems.length === 1 && dataAttrs && Object.keys(dataAttrs).length > 0) {
+			for (var attrName in dataAttrs) {
+				// Omit data attributes already handled by other plugins
+				if (!excludedAttrs.includes(attrName)) htmlElems[0].dataset[attrName] = dataAttrs[attrName] || '';
+			}
+		}
+	});
+};

--- a/src/plugins/sync-data-attrs/client.js
+++ b/src/plugins/sync-data-attrs/client.js
@@ -11,7 +11,7 @@ module.exports = function clientSyncDataAttrs(client) {
 		if (htmlElems.length === 1 && dataAttrs && Object.keys(dataAttrs).length > 0) {
 			for (var attrName in dataAttrs) {
 				// Omit data attributes already handled by other plugins
-				if (!excludedAttrs.includes(attrName)) htmlElems[0].dataset[attrName] = dataAttrs[attrName] || '';
+				if (!excludedAttrs.includes(attrName)) htmlElems[0].dataset[attrName] = dataAttrs[attrName];
 			}
 		}
 	});

--- a/src/plugins/sync-data-attrs/client.js
+++ b/src/plugins/sync-data-attrs/client.js
@@ -5,7 +5,7 @@ var excludedAttrs = [
 	'timezone'
 ];
 
-module.exports = function clientSyncDataAttrs(client) {
+function clientSyncDataAttrs(client) {
 	return client.request('attrs').then(function(dataAttrs) {
 		var htmlElems = document.getElementsByTagName('html');
 		if (htmlElems.length === 1 && dataAttrs && Object.keys(dataAttrs).length > 0) {
@@ -15,4 +15,6 @@ module.exports = function clientSyncDataAttrs(client) {
 			}
 		}
 	});
-};
+}
+
+module.exports.default = clientSyncDataAttrs;

--- a/src/plugins/sync-data-attrs/host.js
+++ b/src/plugins/sync-data-attrs/host.js
@@ -2,5 +2,6 @@ module.exports = function hostSyncDataAttrs(host) {
 	host.onRequest('attrs', function() {
 		var htmlElems = document.getElementsByTagName('html');
 		if (htmlElems.length === 1 && htmlElems[0].hasAttributes()) return Object.assign({}, htmlElems[0].dataset);
+		return {};
 	});
 };

--- a/src/plugins/sync-data-attrs/host.js
+++ b/src/plugins/sync-data-attrs/host.js
@@ -1,0 +1,6 @@
+module.exports = function hostSyncDataAttrs(host) {
+	host.onRequest('attrs', function() {
+		var htmlElems = document.getElementsByTagName('html');
+		if (htmlElems.length === 1 && htmlElems[0].hasAttributes()) return Object.assign({}, htmlElems[0].dataset);
+	});
+};

--- a/test/client.js
+++ b/test/client.js
@@ -7,10 +7,11 @@ require('chai')
 	.should();
 
 const Client = require('../client');
+const clientSyncDataAttrs = require('../src/plugins/sync-data-attrs/client');
 
 describe('client', () => {
 
-	var client, sendEvent, sendMessage, clock;
+	var client, sendEvent, sendMessage, syncDataAttrs, clock;
 
 	beforeEach(() => {
 		global.window = {
@@ -29,6 +30,8 @@ describe('client', () => {
 				appendChild: sinon.stub()
 			}
 		};
+
+		syncDataAttrs = sinon.stub(clientSyncDataAttrs, 'default').returns(Promise.resolve());
 		client = new Client({ syncLang: false, syncTitle: false });
 		sendEvent = sinon.stub(client, 'sendEvent');
 		sendMessage = sinon.stub(client, '_sendMessage');
@@ -38,6 +41,7 @@ describe('client', () => {
 	afterEach(() => {
 		sendEvent.restore();
 		sendMessage.restore();
+		syncDataAttrs.restore();
 		clock.restore();
 	});
 

--- a/test/plugins/sync-data-attrs.js
+++ b/test/plugins/sync-data-attrs.js
@@ -1,0 +1,178 @@
+const
+	expect = require('chai').expect,
+	sinon = require('sinon');
+
+require('chai')
+	.use(require('sinon-chai'))
+	.should();
+
+const
+	clientSyncDataAttrs = require('../../src/plugins/sync-data-attrs/client'),
+	hostSyncDataAttrs = require('../../src/plugins/sync-data-attrs/host');
+
+const MockClient = function() {};
+MockClient.prototype.request = function() {};
+
+const MockHost = function() {};
+MockHost.prototype.onRequest = function() {};
+
+describe('sync-data-attrs', () => {
+	let getElementsByTagName;
+
+	beforeEach(() => {
+		getElementsByTagName = sinon.stub();
+		global.document = {
+			getElementsByTagName: getElementsByTagName
+		};
+		global.window = {
+			location: { protocol: 'https:', origin: 'https://dummy' },
+			URL: class {
+				constructor(path, base) {
+					this._href = `${base}/${path}`;
+				}
+				get href() {
+					return this._href;
+				}
+			}
+		};
+	});
+
+	describe('client', () => {
+		let client, request;
+
+		beforeEach(() => {
+			client = new MockClient();
+			request = sinon.stub(client, 'request');
+		});
+
+		it('should request for "attrs"', () => {
+			getElementsByTagName
+				.withArgs('html')
+				.returns([]);
+			request
+				.withArgs('attrs')
+				.returns(Promise.resolve({}));
+			clientSyncDataAttrs(client);
+			request.should.have.been.calledWith('attrs');
+		});
+
+		it('should apply data attributes to HTML element', (done) => {
+
+			const dataAttrs = {
+				testAttr: 'someValue',
+				anotherTestAttr: 'someOtherValue'
+			};
+
+			const dataset = {};
+			getElementsByTagName
+				.withArgs('html')
+				.returns([{
+					dataset: dataset
+				}]);
+
+			request
+				.withArgs('attrs')
+				.returns(Promise.resolve(dataAttrs));
+
+			clientSyncDataAttrs(client).then(() => {
+				expect(dataset).to.deep.equal(dataAttrs);
+				done();
+			});
+		});
+
+		it('should not apply excluded data attributes to HTML element', (done) => {
+
+			const dataAttrs = {
+				testAttr: 'someValue',
+				timezone: 'someTimezone'
+			};
+
+			const dataset = {};
+			getElementsByTagName
+				.withArgs('html')
+				.returns([{
+					dataset: dataset
+				}]);
+
+			request
+				.withArgs('attrs')
+				.returns(Promise.resolve(dataAttrs));
+
+			clientSyncDataAttrs(client).then(() => {
+				expect(dataset).to.have.key('testAttr');
+				expect(dataset).to.not.have.key('timezone');
+				done();
+			});
+		});
+
+		it('should do nothing if HTML element is not present', (done) => {
+
+			getElementsByTagName
+				.withArgs('html')
+				.returns([]);
+
+			request
+				.withArgs('attrs')
+				.returns(new Promise((resolve) => {
+					resolve(true);
+				}));
+
+			clientSyncDataAttrs(client).then(done);
+		});
+	});
+
+	describe('host', () => {
+		var host, onRequest;
+
+		beforeEach(() => {
+			host = new MockHost();
+			onRequest = sinon.spy(host, 'onRequest');
+		});
+
+		it('should add request handler for "attrs"', () => {
+			hostSyncDataAttrs(host);
+			onRequest.should.have.been.calledWith('attrs');
+		});
+
+		it('should return all data attributes from HTML element', () => {
+
+			const dataAttrs = {
+				testAttr: 'someValue',
+				anotherTestAttr: 'someOtherValue',
+				timezone: 'someTimezone'
+			};
+
+			const hasAttributes = sinon.stub();
+			hasAttributes.returns(true);
+
+			getElementsByTagName
+				.withArgs('html')
+				.returns([{
+					dataset: dataAttrs,
+					hasAttributes: hasAttributes
+				}]);
+
+			hostSyncDataAttrs(host);
+
+			const value = onRequest.args[0][1]();
+			expect(value).to.deep.eql(dataAttrs);
+		});
+
+		it('should return empty object if no attributes are present', () => {
+
+			const hasAttributes = sinon.stub();
+			hasAttributes.returns(false);
+
+			getElementsByTagName
+				.withArgs('html')
+				.returns([{
+					hasAttributes: hasAttributes
+				}]);
+
+			hostSyncDataAttrs(host);
+
+			const value = onRequest.args[0][1]();
+			expect(value).to.be.undefined;
+		});
+	});
+});

--- a/test/plugins/sync-data-attrs.js
+++ b/test/plugins/sync-data-attrs.js
@@ -7,7 +7,7 @@ require('chai')
 	.should();
 
 const
-	clientSyncDataAttrs = require('../../src/plugins/sync-data-attrs/client'),
+	clientSyncDataAttrs = require('../../src/plugins/sync-data-attrs/client').default,
 	hostSyncDataAttrs = require('../../src/plugins/sync-data-attrs/host');
 
 const MockClient = function() {};

--- a/test/plugins/sync-data-attrs.js
+++ b/test/plugins/sync-data-attrs.js
@@ -172,7 +172,7 @@ describe('sync-data-attrs', () => {
 			hostSyncDataAttrs(host);
 
 			const value = onRequest.args[0][1]();
-			expect(value).to.be.undefined;
+			expect(value).to.be.empty;
 		});
 	});
 });


### PR DESCRIPTION
To make it a bit easier (and more pleasant) to pass context objects from the LMS to FRAs, we can add some functionality to marshal any data attributes on the parent document into the iframe's document. This should leave existing clients alone (since we only do the marshaling on client request), but allow anyone who updates to the newest client the ability to grab these context objects straight from their iframe document instead of needing to propagate a bunch of ifrau services as a go-between.