### PR TITLE
feat: add ability to sync feature flag data into iframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,20 +55,21 @@ Parameters:
 * `parentProvider`: function which will return the parent HTML element into which to insert the `IFRAME`
 * `endpoint`: URL of the free-range app endpoint (the `src` of the `IFRAME`)
 * `options`
- * `debug`: whether to enable console debugging, `false` by default
- * `resizeFrame`: whether the `IFRAME` should automatically resize to fit its content, `true` by default
- * `syncFont`: whether to allow client to automatically sync its font size with the host, `false` by default
- * `syncLang`: whether to allow client to automatically sync its language, timezone, internationalization, and OSLO settings with the host, `false` by default
- * `syncPageTitle`: whether the page title (in the `<head>` element) should be kept in sync automatically with the title of the FRA, `false` by default
- * `syncCssVariable`: whether css variables (in the `<head>` element) should be kept in sync automatically with the css variables of the FRA, `false` by default
- * `height`: sets the iframe to a certain height, also disables automatic resizing
- * `id`: sets the id of the iframe
- * `allowFullScreen`: whether the frame can be placed into full screen mode, `false` by default
- * `allowMicrophone`: whether the frame will allow access to the microphone, `false` by default
- * `allowCamera`: whether the frame will allow access to the camera, `false` by default
- * `allowScreenCapture`: whether the frame will allow access to record the screen, `false` by default
- * `allowEncryptedMedia`:  whether the frame will allow access to encrypted media, `false` by default
- * `allowAutoplay`:  whether the frame will allow access to autoplay, `false` by default
+* `debug`: whether to enable console debugging, `false` by default
+* `resizeFrame`: whether the `IFRAME` should automatically resize to fit its content, `true` by default
+* `syncFont`: whether to allow client to automatically sync its font size with the host, `false` by default
+* `syncLang`: whether to allow client to automatically sync its language, timezone, internationalization, and OSLO settings with the host, `false` by default
+* `syncPageTitle`: whether the page title (in the `<head>` element) should be kept in sync automatically with the title of the FRA, `false` by default
+* `syncCssVariable`: whether css variables (in the `<head>` element) should be kept in sync automatically with the css variables of the FRA, `false` by default
+* `syncFlags`: whether to allow client to automatically sync its client registered feature flags with the host, `false` by default
+* `height`: sets the iframe to a certain height, also disables automatic resizing
+* `id`: sets the id of the iframe
+* `allowFullScreen`: whether the frame can be placed into full screen mode, `false` by default
+* `allowMicrophone`: whether the frame will allow access to the microphone, `false` by default
+* `allowCamera`: whether the frame will allow access to the camera, `false` by default
+* `allowScreenCapture`: whether the frame will allow access to record the screen, `false` by default
+* `allowEncryptedMedia`:  whether the frame will allow access to encrypted media, `false` by default
+* `allowAutoplay`:  whether the frame will allow access to autoplay, `false` by default
 
 Creating a Client is even simpler:
 
@@ -86,12 +87,13 @@ client
 Parameters:
 
 * `options`
- * `debug`: whether to enable console debugging, `false` by default
- * `resizeFrame`: whether this `Client` should participate in automatic resizing. `true` by default
- * `syncFont`: whether the font size should be automatically set to match the host page, `false` by default
- * `syncLang`: whether the page's language tag should be automatically set to match the host page, `true` by default
- * `syncTitle`: whether the host page's title and `IFRAME` element title should be kept in sync with the FRA's title, `true` by default
- * `resizerOptions`: pass iframe-resizer client options through to the iframe resizer client
+* `debug`: whether to enable console debugging, `false` by default
+* `resizeFrame`: whether this `Client` should participate in automatic resizing. `true` by default
+* `syncFont`: whether the font size should be automatically set to match the host page, `false` by default
+* `syncLang`: whether the page's language tag should be automatically set to match the host page, `true` by default
+* `syncTitle`: whether the host page's title and `IFRAME` element title should be kept in sync with the FRA's title, `true` by default
+* `syncFlags`: whether the page's feature flags should be automatically set up to match the host page, `false` by default
+* `resizerOptions`: pass iframe-resizer client options through to the iframe resizer client
 
 ## Events
 

--- a/README.md
+++ b/README.md
@@ -55,21 +55,20 @@ Parameters:
 * `parentProvider`: function which will return the parent HTML element into which to insert the `IFRAME`
 * `endpoint`: URL of the free-range app endpoint (the `src` of the `IFRAME`)
 * `options`
-* `debug`: whether to enable console debugging, `false` by default
-* `resizeFrame`: whether the `IFRAME` should automatically resize to fit its content, `true` by default
-* `syncFont`: whether to allow client to automatically sync its font size with the host, `false` by default
-* `syncLang`: whether to allow client to automatically sync its language, timezone, internationalization, and OSLO settings with the host, `false` by default
-* `syncPageTitle`: whether the page title (in the `<head>` element) should be kept in sync automatically with the title of the FRA, `false` by default
-* `syncCssVariable`: whether css variables (in the `<head>` element) should be kept in sync automatically with the css variables of the FRA, `false` by default
-* `syncFlags`: whether to allow client to automatically sync its client registered feature flags with the host, `false` by default
-* `height`: sets the iframe to a certain height, also disables automatic resizing
-* `id`: sets the id of the iframe
-* `allowFullScreen`: whether the frame can be placed into full screen mode, `false` by default
-* `allowMicrophone`: whether the frame will allow access to the microphone, `false` by default
-* `allowCamera`: whether the frame will allow access to the camera, `false` by default
-* `allowScreenCapture`: whether the frame will allow access to record the screen, `false` by default
-* `allowEncryptedMedia`:  whether the frame will allow access to encrypted media, `false` by default
-* `allowAutoplay`:  whether the frame will allow access to autoplay, `false` by default
+ * `debug`: whether to enable console debugging, `false` by default
+ * `resizeFrame`: whether the `IFRAME` should automatically resize to fit its content, `true` by default
+ * `syncFont`: whether to allow client to automatically sync its font size with the host, `false` by default
+ * `syncLang`: whether to allow client to automatically sync its language, timezone, internationalization, and OSLO settings with the host, `false` by default
+ * `syncPageTitle`: whether the page title (in the `<head>` element) should be kept in sync automatically with the title of the FRA, `false` by default
+ * `syncCssVariable`: whether css variables (in the `<head>` element) should be kept in sync automatically with the css variables of the FRA, `false` by default
+ * `height`: sets the iframe to a certain height, also disables automatic resizing
+ * `id`: sets the id of the iframe
+ * `allowFullScreen`: whether the frame can be placed into full screen mode, `false` by default
+ * `allowMicrophone`: whether the frame will allow access to the microphone, `false` by default
+ * `allowCamera`: whether the frame will allow access to the camera, `false` by default
+ * `allowScreenCapture`: whether the frame will allow access to record the screen, `false` by default
+ * `allowEncryptedMedia`:  whether the frame will allow access to encrypted media, `false` by default
+ * `allowAutoplay`:  whether the frame will allow access to autoplay, `false` by default
 
 Creating a Client is even simpler:
 
@@ -87,13 +86,12 @@ client
 Parameters:
 
 * `options`
-* `debug`: whether to enable console debugging, `false` by default
-* `resizeFrame`: whether this `Client` should participate in automatic resizing. `true` by default
-* `syncFont`: whether the font size should be automatically set to match the host page, `false` by default
-* `syncLang`: whether the page's language tag should be automatically set to match the host page, `true` by default
-* `syncTitle`: whether the host page's title and `IFRAME` element title should be kept in sync with the FRA's title, `true` by default
-* `syncFlags`: whether the page's feature flags should be automatically set up to match the host page, `false` by default
-* `resizerOptions`: pass iframe-resizer client options through to the iframe resizer client
+ * `debug`: whether to enable console debugging, `false` by default
+ * `resizeFrame`: whether this `Client` should participate in automatic resizing. `true` by default
+ * `syncFont`: whether the font size should be automatically set to match the host page, `false` by default
+ * `syncLang`: whether the page's language tag should be automatically set to match the host page, `true` by default
+ * `syncTitle`: whether the host page's title and `IFRAME` element title should be kept in sync with the FRA's title, `true` by default
+ * `resizerOptions`: pass iframe-resizer client options through to the iframe resizer client
 
 ## Events
 

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -37,12 +37,10 @@ function Client(options) {
 	if (options.syncCssVariable) {
 		this.use(syncCssVariable);
 	}
-	if (options.syncFlags) {
-		this.use(syncFlags);
-	}
 	this.use(userActivityEvents);
 	this.use(syncTitle(options.syncTitle));
 	this.use(syncDataAttrs.default);
+	this.use(syncFlags);
 }
 inherits(Client, SlimClient);
 

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -10,7 +10,8 @@ var SlimClient = require('./slim'),
 	syncFont = require('../plugins/sync-font/client'),
 	syncCssVariable = require('../plugins/sync-css-variable/client'),
 	userActivityEvents = require('../plugins/user-activity-events/client'),
-	syncOslo = require('../plugins/sync-oslo/client');
+	syncOslo = require('../plugins/sync-oslo/client'),
+	syncFlags = require('../plugins/sync-flags/client');
 
 function Client(options) {
 	if (!(this instanceof Client)) {
@@ -35,6 +36,9 @@ function Client(options) {
 	}
 	if (options.syncCssVariable) {
 		this.use(syncCssVariable);
+	}
+	if (options.syncFlags) {
+		this.use(syncFlags);
 	}
 	this.use(userActivityEvents);
 	this.use(syncTitle(options.syncTitle));

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -40,7 +40,7 @@ function Client(options) {
 	this.use(userActivityEvents);
 	this.use(syncTitle(options.syncTitle));
 	this.use(syncDataAttrs.default);
-	this.use(syncFlags);
+	this.use(syncFlags.default);
 }
 inherits(Client, SlimClient);
 

--- a/src/host.js
+++ b/src/host.js
@@ -57,9 +57,7 @@ function Host(elementProvider, src, options) {
 		this.use(syncCssVariable);
 	}
 	this.use(syncDataAttrs);
-	if (options.syncFlags) {
-		this.use(syncFlags);
-	}
+	this.use(syncFlags);
 }
 inherits(Host, Port);
 

--- a/src/host.js
+++ b/src/host.js
@@ -9,7 +9,8 @@ var Port = require('./port'),
 	syncTimezone = require('./plugins/sync-timezone/host'),
 	syncTitle = require('./plugins/sync-title/host'),
 	syncCssVariable = require('./plugins/sync-css-variable/host'),
-	syncOslo = require('./plugins/sync-oslo/host');
+	syncOslo = require('./plugins/sync-oslo/host'),
+	syncFlags = require('./plugins/sync-flags/host');
 
 var originRe = /^(http:\/\/|https:\/\/)[^/]+/i;
 
@@ -56,6 +57,9 @@ function Host(elementProvider, src, options) {
 		this.use(syncCssVariable);
 	}
 	this.use(syncDataAttrs);
+	if (options.syncFlags) {
+		this.use(syncFlags);
+	}
 }
 inherits(Host, Port);
 

--- a/src/plugins/sync-flags/client.js
+++ b/src/plugins/sync-flags/client.js
@@ -13,6 +13,6 @@ function clientSyncFlags(client) {
 			}
 		};
 	});
-};
+}
 
 module.exports.default = clientSyncFlags;

--- a/src/plugins/sync-flags/client.js
+++ b/src/plugins/sync-flags/client.js
@@ -1,4 +1,4 @@
-module.exports = function clientSyncFlags(client) {
+function clientSyncFlags(client) {
 	return client.request('flags').then(function(flags) {
 		window.D2L = window.D2L || {};
 		window.D2L.LP = window.D2L.LP || {};
@@ -14,3 +14,5 @@ module.exports = function clientSyncFlags(client) {
 		};
 	});
 };
+
+module.exports.default = clientSyncFlags;

--- a/src/plugins/sync-flags/client.js
+++ b/src/plugins/sync-flags/client.js
@@ -1,0 +1,16 @@
+module.exports = function clientSyncFlags(client) {
+	return client.request('flags').then(function(flags) {
+		window.D2L = window.D2L || {};
+		window.D2L.LP = window.D2L.LP || {};
+		window.D2L.LP.Web = window.D2L.LP.Web || {};
+		window.D2L.LP.Web.UI = window.D2L.LP.Web.UI || {};
+		window.D2L.LP.Web.UI.Flags = window.D2L.LP.Web.UI.Flags || {
+			ListedFlags: flags || {},
+			Flag: function(feature, defaultValue) {
+				const featureValue = window.D2L.LP.Web.UI.Flags.ListedFlags[feature];
+
+				return featureValue !== undefined ? featureValue : defaultValue;
+			}
+		};
+	});
+};

--- a/src/plugins/sync-flags/host.js
+++ b/src/plugins/sync-flags/host.js
@@ -1,0 +1,10 @@
+module.exports = function hostSyncFlags(host) {
+	host.onRequest('flags', function() {
+		if (!window.D2L || !window.D2L.LP || !window.D2L.LP.Web ||
+			!window.D2L.LP.Web.UI || !window.D2L.LP.Web.UI.Flags) {
+			return {};
+		}
+
+		return window.D2L.LP.Web.UI.Flags.ListedFlags;
+	});
+};

--- a/test/client.js
+++ b/test/client.js
@@ -12,7 +12,7 @@ const clientSyncFlags = require('../src/plugins/sync-flags/client');
 
 describe('client', () => {
 
-	var client, sendEvent, sendMessage, syncDataAttrs, clock;
+	var client, sendEvent, sendMessage, syncDataAttrs, syncFlags, clock;
 
 	beforeEach(() => {
 		global.window = {

--- a/test/client.js
+++ b/test/client.js
@@ -8,6 +8,7 @@ require('chai')
 
 const Client = require('../client');
 const clientSyncDataAttrs = require('../src/plugins/sync-data-attrs/client');
+const clientSyncFlags = require('../src/plugins/sync-flags/client');
 
 describe('client', () => {
 
@@ -32,6 +33,7 @@ describe('client', () => {
 		};
 
 		syncDataAttrs = sinon.stub(clientSyncDataAttrs, 'default').returns(Promise.resolve());
+		syncFlags = sinon.stub(clientSyncFlags, 'default').returns(Promise.resolve());
 		client = new Client({ syncLang: false, syncTitle: false });
 		sendEvent = sinon.stub(client, 'sendEvent');
 		sendMessage = sinon.stub(client, '_sendMessage');
@@ -42,6 +44,7 @@ describe('client', () => {
 		sendEvent.restore();
 		sendMessage.restore();
 		syncDataAttrs.restore();
+		syncFlags.restore();
 		clock.restore();
 	});
 

--- a/test/plugins/sync-flags.js
+++ b/test/plugins/sync-flags.js
@@ -1,0 +1,104 @@
+const
+	expect = require('chai').expect,
+	sinon = require('sinon');
+
+require('chai')
+	.use(require('sinon-chai'))
+	.should();
+
+const
+	clientSyncFlags = require('../../src/plugins/sync-flags/client'),
+	hostSyncFlags = require('../../src/plugins/sync-flags/host');
+
+const MockClient = function() { };
+MockClient.prototype.request = function() { };
+
+const MockHost = function() { };
+MockHost.prototype.onRequest = function() { };
+
+describe('sync-flags', () => {
+
+	const flagName = 'test';
+	const flags = { [flagName]: true };
+
+	describe('host', () => {
+
+		var host, onRequest;
+
+		beforeEach(() => {
+			global.window = {
+				D2L: {
+					LP: {
+						Web: {
+							UI: {
+								Flags: {
+									ListedFlags: flags
+								}
+							}
+						}
+					}
+				}
+			};
+			host = new MockHost();
+			onRequest = sinon.spy(host, 'onRequest');
+		});
+
+		afterEach(() => {
+			onRequest.restore();
+		});
+
+		it('should add request handler for "flags"', () => {
+			hostSyncFlags(host);
+			onRequest.should.have.been.calledWith('flags');
+		});
+
+		it('should return flags', () => {
+			hostSyncFlags(host);
+			const value = onRequest.args[0][1]();
+			expect(value).to.eql(flags);
+		});
+
+		it('should return empty flags', () => {
+			global.window = {};
+			hostSyncFlags(host);
+			const value = onRequest.args[0][1]();
+			expect(value).to.eql({});
+		});
+
+	});
+
+	describe('client', () => {
+
+		var client, request, response;
+
+		beforeEach(() => {
+			response = flags;
+			client = new MockClient();
+			request = sinon.stub(client, 'request').returns(
+				new Promise((resolve) => {
+					resolve(response);
+				})
+			);
+		});
+
+		afterEach(() => {
+			request.restore();
+		});
+
+		it('should request flags', () => {
+			clientSyncFlags(client);
+			request.should.have.been.calledWith('flags');
+		});
+
+		it('should setup flags', (done) => {
+			clientSyncFlags(client).then(() => {
+				expect(window.D2L.LP.Web.UI.Flags.ListedFlags).to.equal(flags);
+				expect(window.D2L.LP.Web.UI.Flags.Flag(flagName, false)).to.be.true;
+				expect(window.D2L.LP.Web.UI.Flags.Flag('invalid', 0)).to.eql(0);
+				done();
+			});
+		});
+
+	});
+
+});

--- a/test/plugins/sync-flags.js
+++ b/test/plugins/sync-flags.js
@@ -7,7 +7,7 @@ require('chai')
 	.should();
 
 const
-	clientSyncFlags = require('../../src/plugins/sync-flags/client'),
+	clientSyncFlags = require('../../src/plugins/sync-flags/client').default,
 	hostSyncFlags = require('../../src/plugins/sync-flags/host');
 
 const MockClient = function() { };


### PR DESCRIPTION
Only syncs flags that are registered for client side use. Makes them available via the same mechanism as the LMS which is `window.D2L.LP.Web.UI.Flags(name, defaultValue)`. I know this is very MVCish but I did it now for consistency of usage. We can look at a feature flag utility library or something like that at a later date (maybe next inspiration/dragon slayer). Recommend review with [white-space diff off](https://github.com/Brightspace/ifrau/pull/132/files?w=1).