### PR TITLE
Use more specific entrypoints to avoid having the consumer load more than it needs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ It will build an `IFRAME` element, point it at the FRA endpoint, and wait for th
 To create a Host:
 
 ```javascript
-import { Host } from 'ifrau';
+import { Host } from 'ifrau/host.js';
 
 function parentProvider() {
     return document.getElementById('myParentId');
@@ -60,7 +60,7 @@ Parameters:
 Creating a Client is even simpler:
 
 ```javascript
-import { Client } from 'ifrau';
+import { Client } from 'ifrau/client/client.js';
 
 var client = new Client(options);
 client
@@ -83,7 +83,7 @@ Parameters:
 Creating a SlimClient can be done in the same way:
 
 ```javascript
-import { SlimClient } from 'ifrau';
+import { SlimClient } from 'ifrau/client/slim-client.js';
 
 var slimClient = new SlimClient(options);
 slimClient

--- a/index.js
+++ b/index.js
@@ -1,5 +1,0 @@
-import { Client } from './client/client.js';
-import { Host } from './host.js';
-import { SlimClient } from './client/slim-client.js';
-
-export { Client, Host, SlimClient };

--- a/package.json
+++ b/package.json
@@ -3,13 +3,16 @@
   "version": "0.38.2",
   "description": "Free-range app utility for IFRAME-based FRAs",
   "type": "module",
-  "exports": "./index.js",
+  "exports": {
+    "./client/client.js": "./client/client.js",
+    "./client/slim-client.js": "./client/slim-client.js",
+    "./host.js": "./host.js"
+  },
   "files": [
     "host.js",
-    "index.js",
-    "/client",
-    "/plugins",
-    "/port"
+    "./client",
+    "./plugins",
+    "./port"
   ],
   "scripts": {
     "lint": "eslint .",


### PR DESCRIPTION
The browser will just download every `import` statement it sees, so using a common `index.js` can lead to loading more than we need to. Some of the plugins are a bit beefy, so especially in the case of the slim client we ideally don't want any of these things to load.