### PR TITLE
Set a flag indicating that a full client has been imported (for child components)

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -11,6 +11,8 @@ import { clientSyncTitle } from '../plugins/sync-title/client.js';
 import { recordUserEvents } from '../plugins/user-activity-events/client.js';
 import { SlimClient } from './slim.js';
 
+window.ifrauClientLoaded = true;
+
 export class Client extends SlimClient {
 
 	constructor(options) {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "scripts": {
     "lint": "eslint .",
-    "test:unit": "mocha --recursive --extension test.js",
+    "test:unit": "mocha -r jsdom-global/register --recursive --extension test.js",
     "test": "npm run lint -s && npm run test:unit -s"
   },
   "repository": {
@@ -44,6 +44,8 @@
     "eslint-plugin-html": "^6",
     "eslint-plugin-import": "^2",
     "eslint-plugin-sort-class-members": "^1",
+    "jsdom": "^17.0.0",
+    "jsdom-global": "^3.0.2",
     "mocha": "~9.1.0",
     "sinon": "^11.1.2",
     "sinon-chai": "^3.7.0"

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -10,23 +10,6 @@ describe('client', () => {
 	let client, sendEvent, sendMessage, use, clock;
 
 	beforeEach(() => {
-		global.window = {
-			addEventListener: sinon.stub(),
-			parent: {
-				postMessage: sinon.stub()
-			}
-		};
-		global.document = {
-			addEventListener: sinon.stub(),
-			body: {
-				scrollHeight: 100
-			},
-			createElement: sinon.stub().returns({ src:'' }),
-			head: {
-				appendChild: sinon.stub()
-			}
-		};
-
 		// sync-title runs sendEvent when it initializes before we can stub it out,.
 		// so prevent any plugins from being loaded at all.
 		use = sinon.stub(Client.prototype, 'use');
@@ -42,6 +25,12 @@ describe('client', () => {
 		sendMessage.restore();
 		use.restore();
 		clock.restore();
+	});
+
+	describe('import', () => {
+		it('should set window loaded flag', () => {
+			expect(window.ifrauClientLoaded).to.be.true;
+		});
 	});
 
 	describe('connect', () => {


### PR DESCRIPTION
If a component creates a `SlimClient`, we need a way to know for sure that we're in an FRA and a full client has been loaded. We can't necessarily rely on  `frau-framed` (https://github.com/Brightspace/frau-framed/blob/master/src/framed.js#L4) because a component used in an arbitrary off-stack UI could still find, for example, that `window.D2L` exists, but `window.D2L.IsNotAnIframedApp` does not, and thus assume incorrectly that we're in an iframed FRA.

A relatively simple way to address this would be to have the full client set a global we can check for to make that determination. Ideally, this global would be set when the client connects so we know we have a fully configured client, or at the very least on construction, so we would know for sure the client was being used. @dlockhart rightly pointed out to me, however, that this causes problems if components load before the client gets constructed and/or connects, since then we might incorrectly assume we're not in an FRA when we in fact are.

So... The idea here is to set this global right on import so it's set as early as possible to eliminate the possibility of this coming up. One notable exception to this is that an FRA could certainly run into trouble if it dynamically imported the client after loading some components, since of course that could happen basically whenever.