### PR TITLE
fix: add additional export

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "exports": {
     "./client.js": "./client/client.js",
+    "./client/client.js": "./client/client.js",	  
     "./client/slim.js": "./client/slim.js",
     "./host.js": "./host.js"
   },


### PR DESCRIPTION
Some older build systems need to have the exact path in order to function correctly. But if you reference the full path it can fail in newer build systems since there is no export for it. Encountered this while trying to PoC some rubric lit stuff in folio-app. This should cover both the cases where we want to reference the client as `ifrau/client/client.js` or `ifrau/client.js`.