### PR TITLE
DE46022: Lessons > 20.21.10.32887>Content>Full screen icon is not visible in Lesson experience

### DIFF
--- a/host.js
+++ b/host.js
@@ -74,7 +74,7 @@ export class Host extends PortWithServices {
 			src,
 			options.id,
 			options.height,
-			options.allowFullscreen,
+			options.allowFullScreen,
 			options.allowMicrophone,
 			options.allowCamera,
 			options.allowScreenCapture,


### PR DESCRIPTION
This PR fixes a typo during the iFrau Convert to ESM module and don't publish to CDN: https://github.com/Brightspace/ifrau/commit/b98211a2e32aece75cbc59025485813ec36879ac#diff-8f5121869870c0a2ace253e2246a0c704384a199947de890dae9fafc7d4dfda4L34

Specifically  `options.allowFullscreen` 
(https://github.com/Brightspace/ifrau/blob/b98211a2e32aece75cbc59025485813ec36879ac/host.js#L77)
should be   `options.allowFullScreen` (https://github.com/Brightspace/ifrau/blob/04be6cde8885a77c899a0581b542723f0a813ff1/src/host.js#L34)

This fill fix the broken the fullscreen functionality for content in Lessons.