### PR TITLE
fix: font size syncing

### DIFF
--- a/plugins/sync-font/client.js
+++ b/plugins/sync-font/client.js
@@ -1,5 +1,5 @@
 export function clientSyncFont(client) {
 	return client.request('font').then(font => {
-		document.documentElement.style.fontSize = font.size;
+		document.documentElement.style.fontSize = font.sizeRoot ?? font.size;
 	});
 }

--- a/plugins/sync-font/client.js
+++ b/plugins/sync-font/client.js
@@ -1,5 +1,5 @@
 export function clientSyncFont(client) {
 	return client.request('font').then(font => {
-		document.documentElement.style.fontSize = font.sizeRoot ?? font.size;
+		document.documentElement.style.fontSize = font.size;
 	});
 }

--- a/plugins/sync-font/host.js
+++ b/plugins/sync-font/host.js
@@ -1,10 +1,13 @@
 export function hostSyncFont(host) {
 	host.onRequest('font', () => {
-		const computedStyle = window.getComputedStyle(document.body);
+		const bodyComputedStyle = window.getComputedStyle(document.body);
+		const rootComputedStyle = window.getComputedStyle(document.documentElement);
 		const visualRedesign = document.body.classList.contains('visual-redesign');
+
 		return {
-			family: computedStyle.fontFamily,
-			size: computedStyle.fontSize,
+			family: bodyComputedStyle.fontFamily,
+			size: bodyComputedStyle.fontSize,
+			sizeRoot: rootComputedStyle.fontSize,
 			visualRedesign: visualRedesign
 		};
 	});

--- a/plugins/sync-font/host.js
+++ b/plugins/sync-font/host.js
@@ -6,9 +6,8 @@ export function hostSyncFont(host) {
 
 		return {
 			family: bodyComputedStyle.fontFamily,
-			size: bodyComputedStyle.fontSize,
-			sizeRoot: rootComputedStyle.fontSize,
-			visualRedesign: visualRedesign
+			size: rootComputedStyle.fontSize,
+			visualRedesign
 		};
 	});
 }

--- a/test/plugins/sync-font.test.js
+++ b/test/plugins/sync-font.test.js
@@ -10,8 +10,7 @@ chai.use(sinonChai).should();
 describe('sync-font', () => {
 
 	const fontFamily = 'comic sans';
-	const rootFontSize = '20px';
-	const bodyFontSize = '10px';
+	const fontSize = '20px';
 	let classListAdd;
 
 	beforeEach(() => {
@@ -19,13 +18,12 @@ describe('sync-font', () => {
 		global.document = {
 			documentElement: {
 				style: {
-					fontSize: rootFontSize
+					fontSize
 				}
 			},
 			body: {
 				style: {
-					fontFamily,
-					fontSize: bodyFontSize
+					fontFamily
 				},
 				classList: {
 					add: classListAdd,
@@ -53,8 +51,7 @@ describe('sync-font', () => {
 		beforeEach(() => {
 			response = {
 				family: fontFamily,
-				size: bodyFontSize,
-				sizeRoot: rootFontSize
+				size: fontSize
 			};
 			client = new MockClient();
 			request = sinon.stub(client, 'request').returns(
@@ -75,24 +72,15 @@ describe('sync-font', () => {
 
 		it('should apply font size to HTML element', (done) => {
 			clientSyncFont(client).then(() => {
-				expect(document.documentElement.style.fontSize).to.equal(rootFontSize);
+				expect(document.documentElement.style.fontSize).to.equal(fontSize);
 				done();
 			});
 		});
 
-		it('should have the same font size no root', (done) => {
-			response.size = '0px';
-			response.sizeRoot = undefined;
+		it('should have the same font size', (done) => {
+			response.size = '13px';
 			clientSyncFont(client).then(() => {
-				expect(document.documentElement.style.fontSize).to.equal('0px');
-				done();
-			});
-		});
-
-		it('should have the same font size with root', (done) => {
-			response.sizeRoot = '30px';
-			clientSyncFont(client).then(() => {
-				expect(document.documentElement.style.fontSize).to.equal('30px');
+				expect(document.documentElement.style.fontSize).to.equal('13px');
 				done();
 			});
 		});
@@ -122,8 +110,7 @@ describe('sync-font', () => {
 			const value = onRequest.args[0][1]();
 			expect(value).to.eql({
 				family: fontFamily,
-				size: bodyFontSize,
-				sizeRoot: rootFontSize,
+				size: fontSize,
 				visualRedesign: false
 			});
 		});
@@ -134,8 +121,7 @@ describe('sync-font', () => {
 			const value = onRequest.args[0][1]();
 			expect(value).to.eql({
 				family: fontFamily,
-				size: bodyFontSize,
-				sizeRoot: rootFontSize,
+				size: fontSize,
 				visualRedesign: true
 			});
 		});


### PR DESCRIPTION
We are grabbing the font size from the body element but setting it on the root document element. This means if the body in the FRA has `d2l-typography` applied then the font size is double scaled down (the root document font size was around `17.1px`, since the LMS side root is `20px` but the body has `d2l-typography` so the body computed size if `17.1px`)