### PR TITLE
Use deumdified iframe-resizer scripts

### DIFF
--- a/plugins/iframe-resizer/client.js
+++ b/plugins/iframe-resizer/client.js
@@ -14,7 +14,7 @@ export function clientResizer(resizerOptions) {
 		}
 
 		const resizerContentWindow = document.createElement('script');
-		resizerContentWindow.src = 'https://s.brightspace.com/lib/iframe-resizer/3.6.5/iframeResizer.contentWindow.js';
+		resizerContentWindow.src = 'https://s.brightspace.com/lib/iframe-resizer/3.6.6/iframeResizer.contentWindow.min.deumdified.js';
 		document.head.appendChild(resizerContentWindow);
 	};
 	return resizer;

--- a/plugins/iframe-resizer/host.js
+++ b/plugins/iframe-resizer/host.js
@@ -16,7 +16,7 @@ export function hostResizer(host) {
 		};
 
 		const resizerScript = document.createElement('script');
-		resizerScript.src = 'https://s.brightspace.com/lib/iframe-resizer/3.6.5/iframeResizer.min.js';
+		resizerScript.src = 'https://s.brightspace.com/lib/iframe-resizer/3.6.6/iframeResizer.min.deumdified.js';
 		resizerScript.onload = resize;
 		document.head.appendChild(resizerScript);
 


### PR DESCRIPTION
New deumdified versions of iframe-resizer have been pushed to the CDN and should be used in place of the old versions; otherwise the LMS can clobber UMD FRAs when loading the ifrau host.