### PR TITLE
Part of solution for DE45931: Prepend origin to LMS-relative URLs (e.g. /d2l/...)

### DIFF
--- a/host.js
+++ b/host.js
@@ -54,7 +54,10 @@ const originRe = /^(http:\/\/|https:\/\/)[^/]+/i;
 const tryGetOrigin = (url) => {
 	if (url && url.indexOf('//') === 0) {
 		url = window.location.protocol + url;
+	} else if (url && url.indexOf('/d2l/') === 0) {
+		url = window.location.origin + url;
 	}
+
 	const match = originRe.exec(url);
 	return (match !== null) ? match[0] : null;
 };

--- a/host.js
+++ b/host.js
@@ -55,7 +55,7 @@ const tryGetOrigin = (url) => {
 	if (url && url.indexOf('//') === 0) {
 		url = window.location.protocol + url;
 	} else if (url && url.indexOf('/d2l/') === 0) {
-		url = window.location.origin + url;
+		return window.location.origin;
 	}
 
 	const match = originRe.exec(url);

--- a/test/host.test.js
+++ b/test/host.test.js
@@ -70,6 +70,11 @@ describe('host', () => {
 			expect(host._targetOrigin).to.equal('https://foo.com');
 		});
 
+		it('should resolve LMS-relative origin', () => {
+			const host = new Host(() => element, '/d2l/foo');
+			expect(host._targetOrigin).to.equal(window.location.origin);
+		});
+
 		it('should throw if parent missing', () => {
 			expect(() => {
 				new Host(() => null, 'http://cdn.com/foo.html');


### PR DESCRIPTION
## Relevant Rally Links

- https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fdefect%2F613811163125


## Description

> With the config variable d2l.Security.AllowContentAccessTokens off, audio and video content topics will not load with the following console error  
>   
> ![image](https://user-images.githubusercontent.com/89945180/194089959-ed262be8-c9e4-4f33-a3cb-790079cf2b48.png)
>   
> This is because the request to the video file doesn't have cookies attached to it. So, they're relying on the content token in the query string of the get to file.


## Goal/Solution

[This PR](https://github.com/Brightspace/lms/pull/28263) adds an LMS URL at that proxies lessons, solving the above issue.  The new URL is specified without domain or scheme and starts with `/d2l/`, which currently isn't a case handled in ifrau.  This PR addresses that.


## Related PRs

- LMS: https://github.com/Brightspace/lms/pull/28263

