### PR TITLE
US158420 - Add option to allow usage of clipboard in iframes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ npm install ifrau
 * **Host**: Created once for each FRA by the AppLoader within Brightspace.
 It will build an `IFRAME` element, point it at the FRA endpoint, and wait for the FRA to load and connect. It can then respond to events and requests from the FRA.
 * **Client**: Created by the free-range app, it will establish communication with the host and can then be used to send/receive requests and events.
-* **SlimClient**: A lighter-weight client created by components within free-range apps that may need to send/receive requests and events with the host. This assumes the parent app has already created a full client to manage syncing options. 
+* **SlimClient**: A lighter-weight client created by components within free-range apps that may need to send/receive requests and events with the host. This assumes the parent app has already created a full client to manage syncing options.
 
 To create a Host:
 
@@ -56,6 +56,7 @@ Parameters:
  * `allowScreenCapture`: whether the frame will allow access to record the screen, `false` by default
  * `allowEncryptedMedia`:  whether the frame will allow access to encrypted media, `false` by default
  * `allowAutoplay`:  whether the frame will allow access to autoplay, `false` by default
+ * `allowClipboard`: whether the frame will allow access to the clipboard (copy/paste), `false` by default
 
 Creating a Client is even simpler:
 

--- a/host.js
+++ b/host.js
@@ -10,7 +10,7 @@ import { hostSyncTimezone } from './plugins/sync-timezone/host.js';
 import { hostSyncTitle } from './plugins/sync-title/host.js';
 import { PortWithServices } from './port/services.js';
 
-const createIFrame = (src, frameId, height, allowFullScreen, allowMicrophone, allowCamera, allowScreenCapture, allowEncryptedMedia, allowAutoplay) => {
+const createIFrame = (src, frameId, height, allowFullScreen, allowMicrophone, allowCamera, allowScreenCapture, allowEncryptedMedia, allowAutoplay, allowClipboard) => {
 	const iframe = document.createElement('iframe');
 	iframe.width = '100%';
 	if (height || height === 0) {
@@ -23,7 +23,7 @@ const createIFrame = (src, frameId, height, allowFullScreen, allowMicrophone, al
 	if (frameId) {
 		iframe.id = frameId;
 	}
-	if (allowMicrophone || allowCamera || allowScreenCapture || allowEncryptedMedia || allowAutoplay) {
+	if (allowMicrophone || allowCamera || allowScreenCapture || allowEncryptedMedia || allowAutoplay || allowClipboard) {
 		const allow = [];
 		if (allowCamera) {
 			allow.push('camera *;');
@@ -39,6 +39,9 @@ const createIFrame = (src, frameId, height, allowFullScreen, allowMicrophone, al
 		}
 		if (allowAutoplay) {
 			allow.push('autoplay *;');
+		}
+		if (allowClipboard) {
+			allow.push('clipboard-write *;');
 		}
 		iframe.setAttribute('allow', allow.join(' '));
 	}


### PR DESCRIPTION
Enabling `clipboard-write` permission to allow us to use the clipboard API in folio-app

https://web.dev/articles/async-clipboard#permissions_policy_integration

Relevant LMS PR:
https://github.com/Brightspace/lms/pull/41825