### PR TITLE
GAUD-9426: remove unnecessary dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,11 +37,6 @@
   },
   "homepage": "https://github.com/Brightspace/ifrau",
   "devDependencies": {
-    "@babel/core": "^7",
-    "@babel/eslint-parser": "^7",
-    "@eslint/compat": "^2",
-    "@eslint/eslintrc": "^3",
-    "@eslint/js": "^9",
     "globals": "^17",
     "chai": "^4",
     "chai-as-promised": "^8",


### PR DESCRIPTION
`@babel/eslint-parser` is a dependency of our own config and the rest aren't necessary. They're preventing an eslint 10 upgrade (among many other things!).