### PR TITLE
GAUD-10132: add option for allowing unload

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Parameters:
  * `allowEncryptedMedia`:  whether the frame will allow access to encrypted media, `false` by default
  * `allowAutoplay`:  whether the frame will allow access to autoplay, `false` by default
  * `allowClipboard`: whether the frame will allow access to the clipboard (copy/paste), `false` by default
+ * `allowUnload`: whether the iframe will allow the window `unload` event (which is deprecated) to execute
 
 Creating a Client is even simpler:
 

--- a/host.js
+++ b/host.js
@@ -10,7 +10,7 @@ import { hostSyncTimezone } from './plugins/sync-timezone/host.js';
 import { hostSyncTitle } from './plugins/sync-title/host.js';
 import { PortWithServices } from './port/services.js';
 
-const createIFrame = (src, frameId, height, allowFullScreen, allowMicrophone, allowCamera, allowScreenCapture, allowEncryptedMedia, allowAutoplay, allowClipboard) => {
+const createIFrame = (src, frameId, height, allowFullScreen, allowMicrophone, allowCamera, allowScreenCapture, allowEncryptedMedia, allowAutoplay, allowClipboard, allowUnload) => {
 	const iframe = document.createElement('iframe');
 	iframe.width = '100%';
 	if (height || height === 0) {
@@ -42,6 +42,9 @@ const createIFrame = (src, frameId, height, allowFullScreen, allowMicrophone, al
 		}
 		if (allowClipboard) {
 			allow.push('clipboard-write *;');
+		}
+		if (allowUnload) {
+			allow.push('unload;');
 		}
 		iframe.setAttribute('allow', allow.join(' '));
 	}
@@ -86,7 +89,8 @@ export class Host extends PortWithServices {
 			options.allowScreenCapture,
 			options.allowEncryptedMedia,
 			options.allowAutoplay,
-			options.allowClipboard
+			options.allowClipboard,
+			options.allowUnload
 		);
 		parent.appendChild(iframe);
 


### PR DESCRIPTION
This is the same as #197, but applied to `0.41.x`.  Because `ifrau` is at `0.x`, adding that as a "feature" would mean upgrading everything in BSI that uses it together, and this needs to be hotfixed so that's not going to work.

I'll separately upgrade everything to `0.42` for the July release.